### PR TITLE
fix: remove invalid lesson moves for rook and queen

### DIFF
--- a/src/features/learn/constants/lessons.ts
+++ b/src/features/learn/constants/lessons.ts
@@ -53,7 +53,6 @@ export const lessons: Lesson[] = [
           "e4f3",
           "e4g2",
           "e4h1",
-          "e4a1",
         ],
       },
       {
@@ -89,7 +88,6 @@ export const lessons: Lesson[] = [
           "e4f3",
           "e4g2",
           "e4h1",
-          "e4a1",
         ],
       },
       {


### PR DESCRIPTION
Removes invalid move entries for the rook and queen from the "Lessons - Chess Pieces" section