### PR TITLE
fix: call countPgnGames to cache pgn_offsets of new files.

### DIFF
--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -71,11 +71,14 @@ export async function createFile({
   };
   await writeTextFile(file, pgn || makePgn(defaultGame()));
   await writeTextFile(file.replace(".pgn", ".info"), JSON.stringify(metadata));
+  
+  const numGames = unwrap(await commands.countPgnGames(file));
+  
   return Result.ok({
     type: "file",
     name: filename,
     path: file,
-    numGames: 1,
+    numGames,
     metadata,
     lastModified: new Date().getUTCSeconds(),
   });


### PR DESCRIPTION
<!-- Pull Request Template -->

## Description

When creating a new file, call countPgnGames to ensure pgn_offsets are cached.   
Avoid throwing "PGN offsets not found for file" from in offset_by_index

Fixes #32

## Type of change
- [x] Bug fix

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

