### PR TITLE
fix: engine options not being applied in games against computer

### DIFF
--- a/src-tauri/src/chess.rs
+++ b/src-tauri/src/chess.rs
@@ -591,9 +591,20 @@ pub async fn get_best_moves(
                             }
                         }
                     }
-                    UciMessage::BestMove { .. } => {
+                    UciMessage::BestMove { best_move, .. } => {
+                        let final_move = best_move.to_string();
+                        let final_best_moves = BestMoves {
+                            multipv: 1,
+                            depth: proc.last_depth,
+                            nodes: 0,
+                            score: proc.last_best_moves.first().map_or(Score::default(), |m| m.score.clone()),
+                            uci_moves: vec![final_move],
+                            san_moves: vec![],
+                            nps: 0,
+                        };
+
                         BestMovesPayload {
-                            best_lines: proc.last_best_moves.clone(),
+                            best_lines: vec![final_best_moves],
                             engine: id.clone(),
                             tab: tab.clone(),
                             fen: proc.options.fen.clone(),
@@ -601,7 +612,10 @@ pub async fn get_best_moves(
                             progress: 100.0,
                         }
                         .emit(&app)?;
+
                         proc.last_progress = 100.0;
+
+                        break;
                     }
                     _ => {}
                 }


### PR DESCRIPTION
<!-- Pull Request Template -->

Description
This pull request resolves an issue where the Stockfish engine's UCI_LimitStrength and Skill Level options were not being correctly applied. The application was acting upon intermediate analysis from the engine's info stream, which contains full-strength moves, rather than waiting for the final, strength-adjusted move provided in the bestmove command.

The fix modifies the Rust backend to specifically listen for the UciMessage::BestMove message. Upon receiving it, the code now extracts the single, definitive move, sends it as the final update to the user interface, and terminates the analysis loop. This ensures that the move played accurately reflects the user's selected skill level.

Fixes #35 

Type of change
[x] Bug fix

[ ] New feature

[ ] Breaking change

[ ] Documentation update

Checklist
[x] My code follows the style guidelines of this project

[x] I have performed a self-review of my own code

[x] I have commented my code, particularly in hard-to-understand areas

[ ] I have made corresponding changes to the documentation

[x] My changes generate no new warnings

[ ] I have added tests that prove my fix is effective or that my feature works

[ ] New and existing unit tests pass locally with my changes

Additional context
Explicit Change in Behaviour:

Previous Behaviour: The application would process the stream of analysis (info lines) from the engine and immediately forward these full-strength move recommendations to the user interface. This meant the UI would act on the best possible move found, disregarding the strength-adjusted move that the engine would select later in its bestmove command.

New Behaviour: The code has been modified to ignore the intermediate info analysis for move selection. It now waits specifically for the final bestmove command from the engine. Upon receiving this command, it extracts the move—which correctly reflects the selected skill level—and sends only this move to the user interface. 