### PR TITLE
feat: generate puzzles in order

### DIFF
--- a/src/bindings/generated.ts
+++ b/src/bindings/generated.ts
@@ -83,15 +83,16 @@ async memorySize() : Promise<bigint> {
  * * `file` - Path to the puzzle database
  * * `min_rating` - Minimum puzzle rating to include
  * * `max_rating` - Maximum puzzle rating to include
+ * * `random` - Randomize puzzle in cache
  * 
  * # Returns
  * * `Ok(Puzzle)` if a puzzle was found
  * * `Err(Error::NoPuzzles)` if no puzzles match the criteria
  * * Other errors if there was a problem accessing the database
  */
-async getPuzzle(file: string, minRating: number, maxRating: number) : Promise<Result<Puzzle, string>> {
+async getPuzzle(file: string, minRating: number, maxRating: number, random: boolean) : Promise<Result<Puzzle, string>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("get_puzzle", { file, minRating, maxRating }) };
+    return { status: "ok", data: await TAURI_INVOKE("get_puzzle", { file, minRating, maxRating, random }) };
 } catch (e) {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };

--- a/src/state/atoms.ts
+++ b/src/state/atoms.ts
@@ -190,6 +190,7 @@ export const hidePuzzleRatingAtom = atomWithStorage<boolean>("hide-puzzle-rating
 export const progressivePuzzlesAtom = atomWithStorage<boolean>("progressive-puzzles", false);
 export const jumpToNextPuzzleAtom = atomWithStorage<boolean>("puzzle-jump-immediately", true);
 export const puzzleRatingRangeAtom = atomWithStorage<[number, number]>("puzzle-ratings", [1000, 1500]);
+export const inOrderPuzzlesAtom = atomWithStorage<boolean>("puzzle-in-order", false);
 
 // CP / WDL
 


### PR DESCRIPTION
<!-- Pull Request Template -->

## Description
Allows to generate puzzles in order. For the lichess db, it sorts by rating & id. For puzzle files, it sorts in order of games.

Having puzzle files allows use to setup a set of puzzles to practice, kind of like the Woodpecker method. Having them in order can help going through the first few iteration of that set of puzzles. It also helps setting up a puzzle file like a workbook.


## Type of change
- [x] New feature

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Fun Fact
In the PuzzleBoard the rating slider goes from 600 to 2800. In the lichess db, the puzzles goes from 545 to 3024 (that's 419 puzzles we're "missing" from the rating slider (of 3080529)