### PR TITLE
fix(BoardGame): same time control out of synch

### DIFF
--- a/src/features/boards/components/BoardGame.tsx
+++ b/src/features/boards/components/BoardGame.tsx
@@ -733,7 +733,17 @@ function BoardGame() {
                       <Checkbox
                         label="Same time control"
                         checked={sameTimeControl}
-                        onChange={(e) => setSameTimeControl(e.target.checked)}
+                        onChange={(e) => {
+                          const isChecked = e.target.checked;
+                          setSameTimeControl(isChecked);
+                          
+                          if (isChecked) {
+                            setPlayer2Settings((prev) => ({
+                              ...prev,
+                              timeControl: player1Settings.timeControl,
+                            }));
+                          }
+                        }}
                       />
                     </Group>
                   </Stack>


### PR DESCRIPTION
## Description

When starting a new game with Same Time Control enabled, both players should have identical time-control settings. Re-enabling Same Time Control after changing one player's time does not synchronize the other player's time, so the two players can end up with different time controls.

## How This Was Tested
- [x] Development testing completed
- [x] Built successfully

**Tested on:**  
Windows

## Steps to Reproduce

- Start a new game with "Same Time Control" checked
- Uncheck "Same Time Control"
- Modify one player's time (e.g., change White to 5min)
- Re-check "Same Time Control"
- Result: White and Black have different time controls (not synced)

## Checklist

- [x] Followed contributing guidelines
- [x] Reviewed code for style and correctness
