### PR TITLE
fix(i18n): replace common.saveAndClose translation key

### DIFF
--- a/src/components/panels/info/InfoPanel.tsx
+++ b/src/components/panels/info/InfoPanel.tsx
@@ -101,7 +101,7 @@ function GameSelectorAccordion({
         title: t("common.unsavedChanges.title"),
         withCloseButton: false,
         children: <Text>{t("common.unsavedChanges.desc")}</Text>,
-        labels: { confirm: t("common.saveAndClose"), cancel: t("common.unsavedChanges.closeWithoutSaving") },
+        labels: { confirm: t("common.unsavedChanges.saveAndClose"), cancel: t("common.unsavedChanges.closeWithoutSaving") },
         onConfirm: async () => {
           if (currentTab) {
             saveToFile({


### PR DESCRIPTION
## Description

Replace non-existent common.saveAndClose i18n translation key with common.unsavedChanges.saveAndClose
