### PR TITLE
fix: toggle pawn structure view

### DIFF
--- a/src/features/boards/components/BoardAnalysis.tsx
+++ b/src/features/boards/components/BoardAnalysis.tsx
@@ -30,6 +30,7 @@ import ResponsiveBoard from "./ResponsiveBoard";
 function BoardAnalysis() {
   const [editingMode, toggleEditingMode] = useToggle();
   const [selectedPiece, setSelectedPiece] = useState<Piece | null>(null);
+  const [viewPawnStructure, setViewPawnStructure] = useState(false);
   const [currentTab, setCurrentTab] = useAtom(currentTabAtom);
   const autoSave = useAtomValue(autoSaveAtom);
   const { documentDir } = useLoaderData({ from: "/boards" });
@@ -168,6 +169,8 @@ function BoardAnalysis() {
               ) : undefined
             }
             // Board controls props
+            viewPawnStructure={viewPawnStructure}
+            setViewPawnStructure={setViewPawnStructure}
             canTakeBack={false} // Analysis mode doesn't support take back
             changeTabType={() => setCurrentTab((prev) => ({ ...prev, type: "play" }))}
             currentTabType="analysis"
@@ -201,6 +204,8 @@ function BoardAnalysis() {
                 ) : undefined
               }
               // Board controls props
+              viewPawnStructure={viewPawnStructure}
+              setViewPawnStructure={setViewPawnStructure}
               canTakeBack={false} // Analysis mode doesn't support take back
               changeTabType={() => setCurrentTab((prev) => ({ ...prev, type: "play" }))}
               currentTabType="analysis"

--- a/src/features/boards/components/BoardGame.tsx
+++ b/src/features/boards/components/BoardGame.tsx
@@ -312,6 +312,7 @@ function BoardGame() {
   const { t } = useTranslation();
 
   const [inputColor, setInputColor] = useState<"white" | "random" | "black">("white");
+  const [viewPawnStructure, setViewPawnStructure] = useState(false);
 
   function cycleColor() {
     setInputColor((prev) =>
@@ -654,6 +655,8 @@ function BoardGame() {
             blackTime={gameState === "playing" ? (blackTime ?? undefined) : undefined}
             topBar={false}
             // Board controls props
+            viewPawnStructure={viewPawnStructure}
+            setViewPawnStructure={setViewPawnStructure}
             changeTabType={changeToAnalysisMode}
             currentTabType="play"
             // Start Game props
@@ -679,6 +682,8 @@ function BoardGame() {
               blackTime={gameState === "playing" ? (blackTime ?? undefined) : undefined}
               topBar={false}
               // Board controls props
+              viewPawnStructure={viewPawnStructure}
+              setViewPawnStructure={setViewPawnStructure}
               changeTabType={changeToAnalysisMode}
               currentTabType="play"
               // Start Game props


### PR DESCRIPTION
## Description

Fixes the "Toggle Pawn Structure View" action

## How This Was Tested
- [x] Development testing completed
- [x] Built successfully

**Tested on:**  
Windows

## Steps to Reproduce

- Open Analysis Board or Play a game
- Click the three‑dot icon (more options) below the board
- Select "Toggle Pawn Structure View", now the board should display only pawns, but nothing happens

## Checklist

- [x] Followed contributing guidelines
- [x] Reviewed code for style and correctness
