### PR TITLE
fix: select and paste pieces in position editor

### DIFF
--- a/src/features/boards/components/BoardAnalysis.tsx
+++ b/src/features/boards/components/BoardAnalysis.tsx
@@ -171,6 +171,8 @@ function BoardAnalysis() {
             // Board controls props
             viewPawnStructure={viewPawnStructure}
             setViewPawnStructure={setViewPawnStructure}
+            selectedPiece={selectedPiece}
+            setSelectedPiece={setSelectedPiece}
             canTakeBack={false} // Analysis mode doesn't support take back
             changeTabType={() => setCurrentTab((prev) => ({ ...prev, type: "play" }))}
             currentTabType="analysis"
@@ -206,6 +208,8 @@ function BoardAnalysis() {
               // Board controls props
               viewPawnStructure={viewPawnStructure}
               setViewPawnStructure={setViewPawnStructure}
+              selectedPiece={selectedPiece}
+              setSelectedPiece={setSelectedPiece}
               canTakeBack={false} // Analysis mode doesn't support take back
               changeTabType={() => setCurrentTab((prev) => ({ ...prev, type: "play" }))}
               currentTabType="analysis"

--- a/src/features/boards/components/BoardGame.tsx
+++ b/src/features/boards/components/BoardGame.tsx
@@ -20,6 +20,7 @@ import {
 } from "@mantine/core";
 import { IconAlertCircle, IconArrowsExchange, IconCpu, IconPlus, IconUser, IconZoomCheck } from "@tabler/icons-react";
 import { useNavigate } from "@tanstack/react-router";
+import type { Piece } from "chessground/types";
 import { parseUci } from "chessops";
 import { INITIAL_FEN } from "chessops/fen";
 import equal from "fast-deep-equal";
@@ -313,6 +314,7 @@ function BoardGame() {
 
   const [inputColor, setInputColor] = useState<"white" | "random" | "black">("white");
   const [viewPawnStructure, setViewPawnStructure] = useState(false);
+  const [selectedPiece, setSelectedPiece] = useState<Piece | null>(null);
 
   function cycleColor() {
     setInputColor((prev) =>
@@ -657,6 +659,8 @@ function BoardGame() {
             // Board controls props
             viewPawnStructure={viewPawnStructure}
             setViewPawnStructure={setViewPawnStructure}
+            selectedPiece={selectedPiece}
+            setSelectedPiece={setSelectedPiece}
             changeTabType={changeToAnalysisMode}
             currentTabType="play"
             // Start Game props
@@ -684,6 +688,8 @@ function BoardGame() {
               // Board controls props
               viewPawnStructure={viewPawnStructure}
               setViewPawnStructure={setViewPawnStructure}
+              selectedPiece={selectedPiece}
+              setSelectedPiece={setSelectedPiece}
               changeTabType={changeToAnalysisMode}
               currentTabType="play"
               // Start Game props

--- a/src/features/boards/components/MobileBoardLayout.tsx
+++ b/src/features/boards/components/MobileBoardLayout.tsx
@@ -1,6 +1,7 @@
 import { ActionIcon, Box, Collapse, Group, Paper, Stack, Text } from "@mantine/core";
 import { useToggle } from "@mantine/hooks";
 import { IconChevronDown, IconChevronUp } from "@tabler/icons-react";
+import type { Piece } from "chessground/types";
 import { memo, Suspense, useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import GameNotation from "@/components/GameNotation";
@@ -44,6 +45,8 @@ interface MobileBoardLayoutProps {
   clearShapes?: () => void;
   toggleOrientation?: () => void;
   currentTabSourceType?: string;
+  selectedPiece?: Piece | null;
+  setSelectedPiece?: (piece: Piece | null) => void;
 
   // Start Game props
   startGame?: () => void;
@@ -86,6 +89,8 @@ function MobileBoardLayout({
   clearShapes,
   toggleOrientation,
   currentTabSourceType,
+  selectedPiece,
+  setSelectedPiece,
 
   // Start Game props
   startGame,
@@ -190,6 +195,8 @@ function MobileBoardLayout({
         clearShapes={clearShapes}
         toggleOrientation={toggleOrientation}
         currentTabSourceType={currentTabSourceType}
+        selectedPiece={selectedPiece}
+        setSelectedPiece={setSelectedPiece}
         // Start Game props
         startGame={startGame}
         gameState={gameState}

--- a/src/features/boards/components/ResponsiveBoard.tsx
+++ b/src/features/boards/components/ResponsiveBoard.tsx
@@ -1,5 +1,6 @@
 import { Box, Stack } from "@mantine/core";
 import { useElementSize } from "@mantine/hooks";
+import type { Piece } from "chessground/types";
 import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import { ResponsiveLoadingWrapper } from "@/components/ResponsiveLoadingWrapper";
 import { ResponsiveSkeleton } from "@/components/ResponsiveSkeleton";
@@ -39,6 +40,8 @@ interface ResponsiveBoardProps {
   clearShapes?: () => void;
   toggleOrientation?: () => void;
   currentTabSourceType?: string;
+  selectedPiece?: Piece | null;
+  setSelectedPiece?: (piece: Piece | null) => void;
   // Start Game props
   startGame?: () => void;
   gameState?: "settingUp" | "playing" | "gameOver";
@@ -77,6 +80,8 @@ function ResponsiveBoard({
   clearShapes,
   toggleOrientation,
   currentTabSourceType,
+  selectedPiece,
+  setSelectedPiece,
   // Start Game props
   startGame,
   gameState,
@@ -207,6 +212,8 @@ function ResponsiveBoard({
                 clearShapes={clearShapes}
                 toggleOrientation={toggleOrientation}
                 currentTabSourceType={currentTabSourceType}
+                selectedPiece={selectedPiece}
+                setSelectedPiece={setSelectedPiece}
                 // Start Game props
                 startGame={startGame}
                 gameState={gameState}
@@ -253,6 +260,8 @@ function ResponsiveBoard({
             clearShapes={clearShapes}
             toggleOrientation={toggleOrientation}
             currentTabSourceType={currentTabSourceType}
+            selectedPiece={selectedPiece}
+            setSelectedPiece={setSelectedPiece}
             // Start Game props
             startGame={startGame}
             gameState={gameState}


### PR DESCRIPTION
## Description

Fixes the select and paste pieces feature, since no piece appears on the board even after selecting a piece and clicking on a square.

## How This Was Tested
- [x] Development testing completed
- [x] Built successfully

**Tested on:**  
Windows

## Steps to Reproduce

- Open Analysis Board
- Click on "Edit Position"
- Select a piece from the palette, then click any square to place it

## Checklist

- [x] Followed contributing guidelines
- [x] Reviewed code for style and correctness
