### PR TITLE
fix: update file path to use db directory instead of puzzles

### DIFF
--- a/src/features/databases/components/AddDatabase.tsx
+++ b/src/features/databases/components/AddDatabase.tsx
@@ -128,7 +128,7 @@ const useDatabaseOperations = (
     async (path: string, title: string, description?: string) => {
       try {
         setLoading(true);
-        const dbPath = await resolve(await appDataDir(), "puzzles", `${title}.db3`);
+        const dbPath = await resolve(await appDataDir(), "db", `${title}.db3`);
         unwrap(await commands.convertPgn(path, dbPath, null, title, description ?? null));
         await setDatabases(await getDatabases());
       } catch (error) {


### PR DESCRIPTION
## Description

When converting a PGN to DB the resulting file was saved to the Puzzles folder instead of the Databases folder, so it never appeared in the Databases page. This moves the output to the correct Databases location.

## How This Was Tested
- [x] Development testing completed
- [x] Built successfully

**Tested on:**  
Windows

## Steps to Reproduce

- Open the Databases page
- Click Add new
- Select Local and then a PGN file
- Click Convert
- No new DB appears on the Databases page (the DB is actually created in the Puzzles folder)

## Checklist

- [x] Followed contributing guidelines
- [x] Reviewed code for style and correctness
