### PR TITLE
fix: stop text from being selectable when unnecessary

### DIFF
--- a/src/styles/global.css.ts
+++ b/src/styles/global.css.ts
@@ -1,6 +1,11 @@
 import { globalStyle } from "@vanilla-extract/css";
 import { vars } from "./theme";
 
+globalStyle("*", {
+  userSelect: "none",
+  WebkitUserSelect: "none",
+});
+
 globalStyle("cg-board square.selected", {
   [vars.darkSelector]: {
     background: "color-mix(in srgb, var(--mantine-primary-color-5) 50%, transparent)",


### PR DESCRIPTION
# Pull Request

## Description
<!--
Briefly describe what this PR does.
If applicable, reference a related issue (e.g., "Related issue: #123").
Include any relevant context for reviewers.
-->
Prevent text that should be non-selectable from being able to be selected.

## How This Was Tested
- [x] Development testing completed
- [x] Built successfully

**Tested on:**  
<!-- e.g., macOS, Windows, Linux, browser versions, devices, etc. -->
MacOS Tahoe 26.0.1

## Checklist
<!-- Ensure the following are addressed -->
- [x] Followed contributing guidelines
- [x] Reviewed code for style and correctness
