### PR TITLE
fix: change coords to lowercase to match chess notation

### DIFF
--- a/src/styles/chessgroundBaseOverride.css
+++ b/src/styles/chessgroundBaseOverride.css
@@ -155,7 +155,6 @@ piece.fading {
   flex-flow: row;
   width: 100%;
   height: 1rem;
-  text-transform: uppercase;
   text-align: center;
 }
 


### PR DESCRIPTION
# Pull Request

## Description
<!--
Briefly describe what this PR does.
If applicable, reference a related issue (e.g., "Related issue: #123").
Include any relevant context for reviewers.
-->
Make coordinates lowercase seems to make more sense as this is the convention that is used in algebraic chess notation.


## How This Was Tested
- [x] Development testing completed
- [x] Built successfully

**Tested on:**  
<!-- e.g., macOS, Windows, Linux, browser versions, devices, etc. -->

MacOS Tahoe 26.0.1

## Screenshots / Additional Context
<!-- Optional: Add screenshots or any additional information that might help reviewers -->

<img width="592" height="593" alt="image" src="https://github.com/user-attachments/assets/765d79a0-32e5-434b-a16d-e131909b02e1" />


## Checklist
<!-- Ensure the following are addressed -->
- [x] Followed contributing guidelines
- [x] Reviewed code for style and correctness
