### PR TITLE
fix: paste fen submission updating board state

### DIFF
--- a/src/components/panels/info/FenSearch.tsx
+++ b/src/components/panels/info/FenSearch.tsx
@@ -16,6 +16,7 @@ export default function FenSearch({ currentFen }: { currentFen: string }) {
   const store = useContext(TreeStateContext)!;
   const headers = useStore(store, (s) => s.headers);
   const setHeaders = useStore(store, (s) => s.setHeaders);
+  const setFen = useStore(store, (s) => s.setFen);
 
   function addFen(fen: string, chess960: boolean) {
     if (fen) {
@@ -23,6 +24,7 @@ export default function FenSearch({ currentFen }: { currentFen: string }) {
       if (res.isErr) {
         setError(res.error);
       } else {
+        setFen(fen);
         setHeaders({
           ...headers,
           fen,
@@ -89,12 +91,11 @@ export default function FenSearch({ currentFen }: { currentFen: string }) {
           error={error && chessopsError(error)}
           rightSection={isLoading && <Loader size={18} />}
           value={search}
-          onChange={(event) => {
+          onInput={(event) => {
             combobox.openDropdown();
             combobox.updateSelectedOptionIndex();
             setSearch(event.currentTarget.value);
           }}
-          onClick={() => combobox.openDropdown()}
           onFocus={() => combobox.openDropdown()}
           onBlur={() => {
             combobox.closeDropdown();


### PR DESCRIPTION
## Description

Pasting a new FEN into the analysis page did not trigger the onChange event, causing the dropdown to display the old FEN instead of the new one. Additionally, the board position does not update even after pressing Enter or clicking on the dropdown entry.

## How This Was Tested
- [x] Development testing completed
- [x] Built successfully

**Tested on:**  
Windows

## Steps to Reproduce

- Open Analysis Page
- Locate the current fen and use Ctrl + V to paste a new one, the dropdown displays the old FEN instead of the one just pasted
- Press Enter or click on the dropdown entry, but the position does not update to reflect the pasted FEN

## Checklist

- [x] Followed contributing guidelines
- [x] Reviewed code for style and correctness
