### PR TITLE
feat(hotkeys): implement hotkey formatting for improved display and accessibility

### DIFF
--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -21,6 +21,7 @@ import { useTranslation } from "react-i18next";
 import { useResponsiveLayout } from "@/hooks/useResponsiveLayout";
 import { keyMapAtom } from "@/state/keybindings";
 import { env } from "@/utils/detectEnvironment";
+import { splitHotkeyDisplay } from "@/utils/formatHotkey";
 import { linksdata } from "./Sidebar";
 import * as classes from "./TopBar.css";
 
@@ -212,9 +213,16 @@ function TopBar({ menuActions }: { menuActions: MenuGroup[] }) {
             <Text pr="200px" c="dimmed" size="sm">
               {t("keybindings.spotlightSearch")}
             </Text>
-            <Kbd size="xs" style={{ borderWidth: "1px" }}>
-              {keyMap.SPOTLIGHT_SEARCH.keys}
-            </Kbd>
+            <Text size="xs" c="dimmed">
+              {splitHotkeyDisplay(keyMap.SPOTLIGHT_SEARCH.keys).map((part: string, i: number, arr: string[]) => (
+                <span key={i}>
+                  <Kbd size="xs" style={{ borderWidth: "1px" }}>
+                    {part}
+                  </Kbd>
+                  {i < arr.length - 1 && <span style={{ marginInline: 4 }}> + </span>}
+                </span>
+              ))}
+            </Text>
           </Group>
         </UnstyledButton>
         <Spotlight

--- a/src/features/settings/components/KeybindInput.tsx
+++ b/src/features/settings/components/KeybindInput.tsx
@@ -5,6 +5,7 @@ import { useAtom } from "jotai";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import useRecordHotkeys from "@/hooks/useRecordHotkeys";
+import { formatHotkeyDisplay } from "@/utils/formatHotkey";
 import { keyMapAtom } from "@/state/keybindings";
 import * as classes from "./KeybindInput.css";
 
@@ -26,7 +27,7 @@ function KeybindInput({
     <>
       {!isRecording ? (
         <Box onMouseEnter={() => setHovering(true)} onMouseLeave={() => setHovering(false)} onClick={() => start()}>
-          <KbdDisplay keys={keybind.keys} hovering={hovering} />
+          <KbdDisplay keys={formatHotkeyDisplay(keybind.keys)} hovering={hovering} />
         </Box>
       ) : (
         <ShortcutInput keys={keys} stop={stop} action={action} />
@@ -75,9 +76,8 @@ function ShortcutInput({ keys, action, stop }: { keys: Set<string>; action: stri
           setKeymap((prev) => ({
             ...prev,
             [action]: {
-              /// @ts-expect-error action is key of keymap
               name: prev[action].name,
-              keys: stringed,
+              keys: stringed, // raw for parser
             },
           }));
         }}

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,3 +1,4 @@
+import { formatHotkeyDisplay } from "@/utils/formatHotkey";
 import { AppShell } from "@mantine/core";
 import { type HotkeyItem, useHotkeys } from "@mantine/hooks";
 import { ModalsProvider, modals } from "@mantine/modals";
@@ -457,19 +458,19 @@ function RootLayout() {
           {
             label: t("features.menu.newTab"),
             id: "new_tab",
-            shortcut: keyMap.NEW_BOARD_TAB.keys,
+            shortcut: formatHotkeyDisplay(keyMap.NEW_BOARD_TAB.keys),
             action: createNewTab,
           },
           {
             label: t("features.menu.openFile"),
             id: "open_file",
-            shortcut: keyMap.OPEN_FILE.keys,
+            shortcut: formatHotkeyDisplay(keyMap.OPEN_FILE.keys),
             action: openNewFile,
           },
           {
             label: t("features.menu.exit"),
             id: "exit",
-            shortcut: keyMap.EXIT_APP.keys,
+            shortcut: formatHotkeyDisplay(keyMap.EXIT_APP.keys),
             action: () => exit(0),
           },
         ],
@@ -480,7 +481,7 @@ function RootLayout() {
           {
             label: t("features.menu.reload"),
             id: "reload",
-            shortcut: keyMap.APP_RELOAD.keys,
+            shortcut: formatHotkeyDisplay(keyMap.APP_RELOAD.keys),
             action: () => location.reload(),
           },
         ],

--- a/src/state/keybindings.ts
+++ b/src/state/keybindings.ts
@@ -1,7 +1,9 @@
 import { atomWithStorage } from "jotai/utils";
 import type { SyncStorage, SyncStringStorage } from "jotai/vanilla/utils/atomWithStorage";
+export type KeyDef = { name: string; keys: string };
 
-const keys = {
+// Base key definitions using platform-agnostic tokens (e.g., "mod", "alt", lowercase keys)
+const baseKeys: Record<string, KeyDef> = {
   // === File Operations ===
   OPEN_FILE: { name: "keybindings.openFile", keys: "mod+o" },
   SAVE_FILE: { name: "keybindings.saveFile", keys: "mod+s" },
@@ -139,9 +141,15 @@ const keys = {
   NEXT_GAME: { name: "keybindings.nextGame", keys: "pagedown" },
 };
 
+// Build initial key map: raw keys only
+const keys: Record<string, KeyDef> = { ...baseKeys };
+
 export const keyMapAtom = atomWithStorage("keybindings", keys, defaultStorage(keys, localStorage));
 
-function defaultStorage<T>(keys: T, storage: SyncStringStorage): SyncStorage<T> {
+function defaultStorage<T extends Record<string, { name: string; keys: string }>>(
+  keys: T,
+  storage: SyncStringStorage,
+): SyncStorage<T> {
   return {
     getItem(key, initialValue) {
       const storedValue = storage.getItem(key);
@@ -149,9 +157,9 @@ function defaultStorage<T>(keys: T, storage: SyncStringStorage): SyncStorage<T> 
         return initialValue;
       }
       const parsed = JSON.parse(storedValue);
-      for (const key in keys) {
-        if (!(key in parsed)) {
-          parsed[key] = keys[key];
+      for (const k in keys) {
+        if (!(k in parsed)) {
+          parsed[k] = keys[k];
         }
       }
       return parsed;

--- a/src/utils/formatHotkey.ts
+++ b/src/utils/formatHotkey.ts
@@ -1,0 +1,68 @@
+// Simple hotkey formatting for display only. Keeps parsers using raw tokens.
+
+const isMac: boolean = navigator.platform.toLowerCase().includes("mac");
+
+function mapTokenForDisplay(token: string, mac: boolean): string {
+  const key = token.trim().toLowerCase();
+  if (!key) return "";
+
+  // Platform-specific modifiers
+  const modifiers: Record<string, string> = {
+    mod: mac ? "⌘" : "Ctrl",
+    ctrl: mac ? "⌃" : "Ctrl",
+    control: mac ? "⌃" : "Ctrl",
+    alt: mac ? "⌥" : "Alt",
+    option: mac ? "⌥" : "Alt",
+    shift: mac ? "⇧" : "Shift",
+  };
+
+  if (key in modifiers) return modifiers[key];
+
+  // Standard key mappings
+  const keyMap: Record<string, string> = {
+    arrowleft: "←",
+    left: "←",
+    arrowright: "→",
+    right: "→",
+    arrowup: "↑",
+    up: "↑",
+    arrowdown: "↓",
+    down: "↓",
+    pageup: "PageUp",
+    pagedown: "PageDown",
+    tab: "Tab",
+    enter: "Enter",
+    return: "Enter",
+    escape: "Escape",
+    esc: "Escape",
+    delete: "Delete",
+    del: "Delete",
+    backspace: "Backspace",
+    space: "Space",
+    spacebar: "Space",
+  };
+
+  if (key in keyMap) return keyMap[key];
+
+  // Function keys
+  const fMatch = /^f(\d{1,2})$/.exec(key);
+  if (fMatch) return `F${fMatch[1]}`;
+
+  // Single letter -> uppercase
+  if (/^[a-z]$/.test(key)) return key.toUpperCase();
+
+  return key.length > 1 ? key[0].toUpperCase() + key.slice(1) : key;
+}
+
+export function formatHotkeyDisplay(combo: string): string {
+  return combo
+    .split("+")
+    .map((t) => mapTokenForDisplay(t, isMac))
+    .join("+");
+}
+
+export function splitHotkeyDisplay(combo: string): string[] {
+  return formatHotkeyDisplay(combo).split("+");
+}
+
+export default formatHotkeyDisplay;


### PR DESCRIPTION
This PR mainly changes the rendering of general key descriptors to their platform-specific counterparts. For example, mod is now rendered as ⌘ on macOS.

Other keys with well known symbols such as arrows are now displayed as symbols rather than text descriptions.