### PR TITLE
fix: puzzle board freeze after wrong move

### DIFF
--- a/src/components/GameNotation.tsx
+++ b/src/components/GameNotation.tsx
@@ -81,7 +81,13 @@ function hasMultipleChildrenUntilPosition(node: TreeNode, remainingPath: number[
   return hasMultipleChildrenUntilPosition(nextNode, remainingPath.slice(1));
 }
 
-function GameNotation({ topBar }: { topBar?: boolean }) {
+function GameNotation({
+  topBar,
+  initialVariationState = "mainline",
+}: {
+  topBar?: boolean;
+  initialVariationState?: VariationState;
+}) {
   const store = useContext(TreeStateContext);
   if (!store) {
     throw new Error("GameNotation must be used within a TreeStateProvider");
@@ -94,10 +100,10 @@ function GameNotation({ topBar }: { topBar?: boolean }) {
   const viewport = useRef<HTMLDivElement>(null);
 
   const [invisibleValue, setInvisible] = useAtom(currentInvisibleAtom);
-  const [variationState, toggleVariationState] = useToggle(["mainline", "variations", "repertoire"]) as [
-    VariationState,
-    () => void,
-  ];
+  const [variationState, toggleVariationState] = useToggle([
+    initialVariationState,
+    ...["mainline", "variations", "repertoire"].filter((v) => v !== initialVariationState),
+  ]) as [VariationState, () => void];
   const [showComments, toggleComments] = useToggle([true, false]);
 
   const invisible = topBar && invisibleValue;

--- a/src/features/boards/components/puzzles/PuzzleBoard.tsx
+++ b/src/features/boards/components/puzzles/PuzzleBoard.tsx
@@ -171,7 +171,7 @@ function PuzzleBoard({
           movable={{
             free: false,
             color:
-              puzzle && equal(position, Array(currentMove).fill(0)) && puzzle.completion === "incomplete"
+              puzzle && equal(position, Array(currentMove).fill(0))
                 ? turn
                 : undefined,
             dests: dests,

--- a/src/features/boards/components/puzzles/Puzzles.tsx
+++ b/src/features/boards/components/puzzles/Puzzles.tsx
@@ -219,7 +219,7 @@ function Puzzles({ id }: { id: string }) {
             </ScrollArea>
           </Paper>
           <Stack flex={1} gap="xs">
-            <GameNotation />
+            <GameNotation initialVariationState="variations" />
             <MoveControls readOnly />
           </Stack>
         </Stack>


### PR DESCRIPTION
## Description

Prevent the board from freezing after an incorrect move in the puzzle. The Puzzle page now displays move variations, whereas before, only the main line was shown. Fixes https://github.com/Pawn-Appetit/pawn-appetit/issues/339

## How This Was Tested
- [x] Development testing completed
- [x] Built successfully

**Tested on:**  
Windows

## Checklist

- [x] Followed contributing guidelines
- [x] Reviewed code for style and correctness
