### PR TITLE
feat: Order games by elo in database games

### DIFF
--- a/src/bindings/generated.ts
+++ b/src/bindings/generated.ts
@@ -628,7 +628,7 @@ export type FidePlayer = { fideid: number; name: string; country: string; sex: s
 export type FileMetadata = { last_modified: bigint; size: bigint; is_dir: boolean; is_readonly: boolean }
 export type GameOutcome = "Won" | "Drawn" | "Lost"
 export type GameQueryJs = { options?: QueryOptions<GameSort> | null; player1?: number | null; player2?: number | null; tournament_id?: number | null; start_date?: string | null; end_date?: string | null; range1?: [number, number] | null; range2?: [number, number] | null; sides?: Sides | null; outcome?: string | null; position?: PositionQueryJs | null; wanted_result?: string | null }
-export type GameSort = "id" | "date" | "whiteElo" | "blackElo" | "ply_count"
+export type GameSort = "id" | "date" | "whiteElo" | "blackElo" | "averageElo" | "ply_count"
 /**
  * Engine search mode (depth, time, nodes, etc).
  */

--- a/src/components/panels/database/DatabasePanel.tsx
+++ b/src/components/panels/database/DatabasePanel.tsx
@@ -41,6 +41,8 @@ export type LocalOptions = {
   start_date?: string;
   end_date?: string;
   result: "any" | "whitewon" | "draw" | "blackwon";
+  sort?: "id" | "date" | "whiteElo" | "blackElo" | "averageElo" | "ply_count";
+  direction?: "asc" | "desc";
 };
 
 function sortOpenings(openings: Opening[]) {

--- a/src/components/panels/database/GamesTable.tsx
+++ b/src/components/panels/database/GamesTable.tsx
@@ -4,13 +4,15 @@ import { IconEye } from "@tabler/icons-react";
 import { useNavigate } from "@tanstack/react-router";
 import { useAtom, useSetAtom } from "jotai";
 import { DataTable } from "mantine-datatable";
-import { memo } from "react";
+import { memo, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { NormalizedGame } from "@/bindings";
 import { useLanguageChangeListener } from "@/hooks/useLanguageChangeListener";
 import { activeTabAtom, tabsAtom } from "@/state/atoms";
 import { parseDate } from "@/utils/format";
 import { createTab } from "@/utils/tabs";
+
+type GameWithAverageElo = NormalizedGame & { averageElo: number | null };
 
 function GamesTable({ games, loading }: { games: NormalizedGame[]; loading: boolean }) {
   const { t } = useTranslation();
@@ -21,12 +23,49 @@ function GamesTable({ games, loading }: { games: NormalizedGame[]; loading: bool
 
   const theme = useMantineTheme();
   const navigate = useNavigate();
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(10);
+
+  // Calculate average ELO for each game (for display only, sorting is done in backend)
+  const gamesWithAverageElo = useMemo<GameWithAverageElo[]>(
+    () =>
+      games.map((game) => {
+        const whiteElo = game.white_elo ?? null;
+        const blackElo = game.black_elo ?? null;
+        let averageElo: number | null = null;
+
+        if (whiteElo !== null && blackElo !== null) {
+          averageElo = Math.round((whiteElo + blackElo) / 2);
+        } else if (whiteElo !== null) {
+          averageElo = whiteElo;
+        } else if (blackElo !== null) {
+          averageElo = blackElo;
+        }
+
+        return { ...game, averageElo };
+      }),
+    [games],
+  );
+
+  // Paginate games (games are already sorted by backend)
+  const paginatedGames = useMemo(() => {
+    const start = (page - 1) * pageSize;
+    const end = start + pageSize;
+    return gamesWithAverageElo.slice(start, end);
+  }, [gamesWithAverageElo, page, pageSize]);
+
   return (
     <DataTable
       withTableBorder
       highlightOnHover
-      records={games}
+      records={paginatedGames}
       fetching={loading}
+      page={page}
+      onPageChange={setPage}
+      totalRecords={gamesWithAverageElo.length}
+      recordsPerPage={pageSize}
+      onRecordsPerPageChange={setPageSize}
+      recordsPerPageOptions={[10, 25, 50, 100]}
       columns={[
         {
           accessor: "actions",
@@ -78,6 +117,11 @@ function GamesTable({ games, loading }: { games: NormalizedGame[]; loading: bool
               </Text>
             </div>
           ),
+        },
+        {
+          accessor: "averageElo",
+          title: "ELO Promedio",
+          render: ({ averageElo }) => <Text fw={500}>{averageElo ?? "-"}</Text>,
         },
         {
           accessor: "date",

--- a/src/utils/db.ts
+++ b/src/utils/db.ts
@@ -210,6 +210,11 @@ export async function searchPosition(options: LocalOptions, tab: string) {
       start_date: options.start_date,
       end_date: options.end_date,
       wanted_result: options.result,
+      options: {
+        skipCount: true,
+        sort: (options.sort || "averageElo") as "id" | "date" | "whiteElo" | "blackElo" | "averageElo" | "ply_count",
+        direction: (options.direction || "desc") as "asc" | "desc",
+      },
     },
     tab,
   );


### PR DESCRIPTION
# Pull Request

Description
This PR refactors the game sorting functionality by moving it from the frontend to the Rust backend. The main changes include:
Removed client-side sorting from GamesTable.tsx component
Added server-side sorting in Rust for better performance and consistency
Added AverageElo sorting option to the GameSort enum
Increased game limit from 50 to 1000 games in position search
Implemented average ELO calculation in Rust (average of white_elo and black_elo)
Default sorting is now by average ELO in descending order (highest ELO first)
The sorting is now performed in the backend before sending data to the frontend, which ensures:
Consistent sorting across all clients
Better performance for large datasets
Proper handling of NULL ELO values
Pagination works correctly with pre-sorted data
Related changes:
Updated searchPosition function to accept and use sorting options
Updated get_games function to support AverageElo sorting
Modified LocalOptions type to include optional sort and direction fields
Frontend now passes sorting preferences to the backend
How This Was Tested
[x] Development testing completed
[x ] Built successfully
Tested on:
Windows 11, Tauri application
Testing steps:
Verified that games are sorted by average ELO in descending order by default
Confirmed pagination works correctly with sorted data
Tested that games with missing ELO values are handled properly (treated as 0)
Checked that sorting calculation matches frontend logic (rounded average)
