### PR TITLE
fix: preserve PGN headers and initial FEN when opening saved games

### DIFF
--- a/src/components/MoveControls.tsx
+++ b/src/components/MoveControls.tsx
@@ -6,6 +6,7 @@ import {
   IconChevronsLeft,
   IconChevronsRight,
   IconPlayerPlay,
+  IconPlayerStop,
 } from "@tabler/icons-react";
 import { useAtomValue } from "jotai";
 import { memo, useContext } from "react";
@@ -38,6 +39,7 @@ interface MoveControlsProps {
   currentTabSourceType?: string;
   // Start Game props for play tabs
   startGame?: () => void;
+  endGame?: () => void;
   gameState?: "settingUp" | "playing" | "gameOver";
   startGameDisabled?: boolean;
 }
@@ -63,6 +65,7 @@ function MoveControls({
   currentTabSourceType,
   // Start Game props
   startGame,
+  endGame,
   gameState,
   startGameDisabled,
 }: MoveControlsProps) {
@@ -113,9 +116,14 @@ function MoveControls({
       >
         <IconChevronLeft />
       </ActionIcon>
-      {currentTabType === "play" && startGame && (
-        <ActionIcon variant="default" size="lg" onClick={startGame} disabled={startGameDisabled}>
-          <IconPlayerPlay />
+      {currentTabType === "play" && (startGame || endGame) && (
+        <ActionIcon
+          variant="default"
+          size="lg"
+          onClick={gameState === "playing" ? endGame : startGame}
+          disabled={gameState === "playing" ? false : startGameDisabled}
+        >
+          {gameState === "playing" ? <IconPlayerStop /> : <IconPlayerPlay />}
         </ActionIcon>
       )}
       <ActionIcon

--- a/src/features/dashboard/DashboardPage.tsx
+++ b/src/features/dashboard/DashboardPage.tsx
@@ -258,7 +258,8 @@ export default function DashboardPage() {
             difficulty: "All",
             onClick: () => {
               const headers = createLocalGameHeaders(last);
-              const pgn = createPGNFromMoves(last.moves, last.result);
+              // Use saved PGN if available, otherwise reconstruct from moves with initial FEN
+              const pgn = last.pgn || createPGNFromMoves(last.moves, last.result, last.initialFen);
 
               createTab({
                 tab: {
@@ -505,7 +506,8 @@ export default function DashboardPage() {
             onRefreshLichess={() => setLastLichessUpdate(Date.now())}
             onAnalyzeLocalGame={(game) => {
               const headers = createLocalGameHeaders(game);
-              const pgn = createPGNFromMoves(game.moves, game.result);
+              // Use saved PGN if available, otherwise reconstruct from moves with initial FEN
+              const pgn = game.pgn || createPGNFromMoves(game.moves, game.result, game.initialFen);
               createTab({
                 tab: {
                   name: `${headers.white} - ${headers.black}`,

--- a/src/locales/en-US/common.json
+++ b/src/locales/en-US/common.json
@@ -208,7 +208,13 @@
     "noEnginesAvailableDesc": "No chess engines are currently installed or detected on your system. To play against an engine, you'll need to install one first.",
     "installEngine": "Install Engine",
     "selectEngine": "Select engine",
-    "openingFor": "opening for"
+    "openingFor": "opening for",
+    "startingPosition": "Starting Position",
+    "fen": "FEN Position",
+    "fenDescription": "Enter a FEN position or leave empty for standard starting position",
+    "applyFen": "Apply FEN",
+    "resetFen": "Reset to initial position",
+    "invalidFen": "Invalid FEN position"
   },
   "databases": {
     "selectDatabasePrompt": "Select a database",

--- a/src/state/store/tree.ts
+++ b/src/state/store/tree.ts
@@ -408,11 +408,21 @@ export const createTreeStore = (id?: string, initialTree?: TreeState) => {
       set(
         produce((state) => {
           state.dirty = true;
-          state.headers = headers;
-          if (headers.fen && headers.fen !== state.root.fen) {
+          // Only update headers metadata, don't reset tree if it has moves
+          // This prevents losing game history when headers are updated
+          const hasMoves = state.root.children.length > 0;
+          
+          // Only reset tree if:
+          // 1. The FEN is different AND
+          // 2. There are no moves in the tree (fresh start)
+          // This allows updating headers without losing game history
+          if (headers.fen && headers.fen !== state.root.fen && !hasMoves) {
             state.root = defaultTree(headers.fen).root;
             state.position = [];
           }
+          
+          // Always update headers metadata
+          state.headers = { ...state.headers, ...headers };
         }),
       ),
     setResult: (result) =>

--- a/src/utils/gameRecords.ts
+++ b/src/utils/gameRecords.ts
@@ -18,7 +18,9 @@ export interface GameRecord {
   timestamp: number;
   moves: string[];
   variant?: string;
-  fen: string;
+  fen: string; // Final FEN position
+  initialFen?: string; // Initial FEN position (if different from standard)
+  pgn?: string; // Full PGN with headers and moves
 }
 
 const FILENAME = "played_games.json";
@@ -50,7 +52,32 @@ export async function getRecentGames(limit = 20): Promise<GameRecord[]> {
   try {
     const text = await readTextFile(file);
     const records: GameRecord[] = JSON.parse(text);
-    return records.slice(0, limit);
+    
+    // Filter out invalid/corrupted games
+    const validRecords = records.filter((record) => {
+      // Must have an id
+      if (!record.id) return false;
+      
+      // Must have valid player information
+      if (!record.white || !record.black) return false;
+      if (!record.white.type || !record.black.type) return false;
+      
+      // Must have moves array (can be empty but must exist)
+      if (!Array.isArray(record.moves)) return false;
+      
+      // Must have a valid timestamp
+      if (!record.timestamp || typeof record.timestamp !== "number") return false;
+      
+      // Must have a result (can be "*" for unfinished games)
+      if (!record.result || typeof record.result !== "string") return false;
+      
+      // Must have a FEN
+      if (!record.fen || typeof record.fen !== "string") return false;
+      
+      return true;
+    });
+    
+    return validRecords.slice(0, limit);
   } catch {
     return [];
   }
@@ -71,5 +98,19 @@ export async function countGamesOnDate(date: Date = new Date()): Promise<number>
     }).length;
   } catch {
     return 0;
+  }
+}
+
+export async function clearAllGames(): Promise<void> {
+  const dir = await appDataDir();
+  const file = await resolve(dir, FILENAME);
+  // Write an empty array to clear all games
+  await writeTextFile(file, JSON.stringify([]));
+  if (typeof window !== "undefined") {
+    try {
+      window.dispatchEvent(new Event("games:updated"));
+    } catch {
+      // ignore
+    }
   }
 }


### PR DESCRIPTION
- Fix createLocalGameHeaders to use initialFen instead of final fen
- Preserve complete PGN headers when opening games from dashboard
- Prevent header overwrite that caused incorrect FEN and missing moves

Previously, when opening a saved game from the dashboard, the headers from createLocalGameHeaders were overwriting the complete PGN headers, causing:
- Final FEN to be used instead of initial FEN
- Incomplete move sequences to be displayed
- Headers to be replaced with default values
