### PR TITLE
fix: ensure directory exists before creating file in FilesPage

### DIFF
--- a/src/features/files/FilesPage.tsx
+++ b/src/features/files/FilesPage.tsx
@@ -155,15 +155,13 @@ function FilesPage() {
         )}
       </Drawer>
 
-      {files && (
-        <CreateModal
-          opened={createModal}
-          setOpened={toggleCreateModal}
-          files={files}
-          setFiles={mutate}
-          setSelected={setSelected}
-        />
-      )}
+      <CreateModal
+        opened={createModal}
+        setOpened={toggleCreateModal}
+        files={files || []}
+        setFiles={mutate}
+        setSelected={setSelected}
+      />
       {selected && files && (
         <EditModal
           key={selected.name}

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -95,6 +95,7 @@ export async function createFile({
     type: filetype,
     tags: [],
   };
+  await mkdir(dir, { recursive: true });
   await writeTextFile(file, pgn || makePgn(defaultGame()));
   await writeTextFile(file.replace(".pgn", ".info"), JSON.stringify(metadata));
 


### PR DESCRIPTION
## Description

On the Files page, the "Create" modal will not open if the Document Directory (Settings -> Directories -> Files Directory) does not exist. This change ensures that the modal always appears, as it will automatically create the needed directory if it is missing.
Fixes https://github.com/Pawn-Appetit/pawn-appetit/issues/370

## How This Was Tested
- [x] Development testing completed
- [x] Built successfully

**Tested on:**  
Windows

## Checklist

- [x] Followed contributing guidelines
- [x] Reviewed code for style and correctness
