### PR TITLE
fix: correct how puzzle streaks are calculated

### DIFF
--- a/src/utils/puzzleStreak.ts
+++ b/src/utils/puzzleStreak.ts
@@ -61,7 +61,7 @@ export function getPuzzleStats(options?: { days?: number; target?: number }) {
     const key = dateKey(addDays(new Date(), -i));
     const solved = (solves[key] ?? 0) > 0;
     if (solved) currentStreak++;
-    else break;
+    else if (i > 0) break;
   }
 
   const history: { day: string; solved: number }[] = [];


### PR DESCRIPTION
# Pull Request

## Description
This fixes how streaks are calculated. Previously, the count would show 0 until a puzzle was completed that day because of how the counting loop was broken. Now, the count will show the correct streak, even if a lesson hasn't been completed on the current day.

## How This Was Tested
- [X] Development testing completed
- [X] Built successfully

**Tested on:**  
Windows 10, Gentoo Linux

## Screenshots / Additional Context
Before: 
<img width="768" height="356" alt="pawn_appetit_streak_count_broken" src="https://github.com/user-attachments/assets/1173c88b-f736-44f5-b00d-65201c6b71f4" />

After:
<img width="770" height="358" alt="pawn_appetit_streak_fixed" src="https://github.com/user-attachments/assets/452ec00b-f9a4-4a2b-b026-1ca6855df9ef" />

## Checklist
<!-- Ensure the following are addressed -->
- [X] Followed contributing guidelines
- [X] Reviewed code for style and correctness
