### PR TITLE
fix: Handle databases over 2GB in size

### DIFF
--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -317,7 +317,7 @@ pub struct DatabaseInfo {
     player_count: i32,
     event_count: i32,
     game_count: i32,
-    storage_size: i32,
+    storage_size: i64,
     filename: String,
     indexed: bool,
 }
@@ -371,7 +371,7 @@ pub async fn get_db_info(
         _ => "".to_string(),
     };
 
-    let storage_size = path.metadata()?.len() as i32;
+    let storage_size = path.metadata()?.len() as i64;
     let filename = path.file_name().expect("get filename").to_string_lossy();
 
     let is_indexed = check_index_exists(db)?;


### PR DESCRIPTION
# Pull Request

## Description
This fixes an issue where databases over ~2.14GB in size have their size incorrectly displayed due to an integer overflow.

## How This Was Tested
- [X] Development testing completed
- [X] Built successfully

**Tested on:**  
Windows 10, Gentoo Linux

## Screenshots / Additional Context
Before:
<img width="459" height="174" alt="pawn_appetit_db_broken" src="https://github.com/user-attachments/assets/00d8e52a-6554-4c66-9207-eeafee85fe46" />

After:
<img width="460" height="176" alt="pawn_appetit_db_size_fixed" src="https://github.com/user-attachments/assets/981da32f-bc7e-4499-9991-0b2682ed156e" />


## Checklist
<!-- Ensure the following are addressed -->
- [X] Followed contributing guidelines
- [X] Reviewed code for style and correctness
