### PR TITLE
Ensure practice positions become available when due date arrives

### DIFF
--- a/src/components/panels/practice/PracticePanel.tsx
+++ b/src/components/panels/practice/PracticePanel.tsx
@@ -385,10 +385,10 @@ function PositionsModal({
                   <Text tt="uppercase" fw="bold" fz="sm">
                     Status
                   </Text>
-                  <Badge color={c.card.reps === 0 ? "gray" : c.card.due < new Date() ? "yellow" : "blue"}>
+                  <Badge color={c.card.reps === 0 ? "gray" : new Date(c.card.due) <= new Date() ? "yellow" : "blue"}>
                     {c.card.reps === 0
                       ? t("features.board.practice.unseen")
-                      : c.card.due < new Date()
+                      : new Date(c.card.due) <= new Date()
                         ? t("features.board.practice.due")
                         : t("features.board.practice.practiced")}
                   </Badge>

--- a/src/features/files/utils/opening.ts
+++ b/src/features/files/utils/opening.ts
@@ -63,12 +63,12 @@ export function getStats(positions: Position[]) {
   for (const card of positions) {
     if (card.card.reps === 0) {
       stats.unseen++;
-    } else if (card.card.due < new Date()) {
+    } else if (new Date(card.card.due) <= new Date()) {
       stats.due++;
     } else {
       stats.practiced++;
     }
-    if (!stats.nextDue || card.card.due < stats.nextDue) {
+    if (!stats.nextDue || new Date(card.card.due) < new Date(stats.nextDue)) {
       stats.nextDue = card.card.due;
     }
   }


### PR DESCRIPTION
## Description
fixes #391 

This PR fixes the issue where the app shows "The next review is on [date]" but positions remain unavailable for practice when that date arrives.


When practice data is stored in localStorage, the `card.due` field is serialized as a string. Direct comparison of date strings to Date objects (`card.due < new Date()`) doesn't work correctly, causing positions to never be marked as "due" even when their review date has passed.


## How This Was Tested
- [x] Development testing completed
~Built successfully~: I couldn't build successfully but this was already the case without these changes just as in my previous PR.

**Tested on:**  
I've tested this on my device and can confirm that it is working as expected.

## Screenshots / Additional Context
<!-- Optional: Add screenshots or any additional information that might help reviewers -->

## Checklist
<!-- Ensure the following are addressed -->
- [x] Followed contributing guidelines
- [x] Reviewed code for style and correctness
