### PR TITLE
fix: audio playback on Linux

### DIFF
--- a/src-tauri/src/app/platform/desktop/linux.rs
+++ b/src-tauri/src/app/platform/desktop/linux.rs
@@ -8,8 +8,13 @@ pub enum LinuxError {
 
 /// Linux-specific platform initialization and configuration
 #[cfg(target_os = "linux")]
-pub fn init_linux_platform() -> Result<(), Box<dyn std::error::Error>> {
+pub fn init_linux_platform(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     log::info!("Initializing Linux-specific features");
+
+    use tauri::Manager;
+    let resource_dir = app.path().resource_dir()?;
+    crate::sound::start_sound_server(resource_dir)?;
+
     Ok(())
 }
 

--- a/src-tauri/src/app/platform/desktop/mod.rs
+++ b/src-tauri/src/app/platform/desktop/mod.rs
@@ -30,7 +30,7 @@ pub fn init_desktop_platform(app: &tauri::App) -> Result<(), Box<dyn std::error:
     macos::init_macos_platform()?;
     
     #[cfg(target_os = "linux")]
-    linux::init_linux_platform()?;
+    linux::init_linux_platform(app)?;
     
     Ok(())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -15,6 +15,7 @@ mod opening;
 mod package_manager;
 mod pgn;
 mod puzzle;
+mod sound;
 mod telemetry;
 
 use std::sync::{Arc, Mutex};
@@ -47,6 +48,7 @@ use crate::package_manager::{
 };
 use crate::pgn::{count_pgn_games, delete_game, read_games, write_game};
 use crate::puzzle::{get_puzzle, get_puzzle_db_info, get_puzzle_rating_range, import_puzzle_file};
+use crate::sound::get_sound_server_port;
 use crate::telemetry::{get_telemetry_config, get_telemetry_enabled, set_telemetry_enabled, get_user_country_api, get_user_country_locale, get_user_id_command, get_platform_info_command};
 use crate::{
     db::{
@@ -156,7 +158,8 @@ pub async fn run() {
             install_package,
             check_package_installed,
             find_executable_path,
-            open_external_link
+            open_external_link,
+            get_sound_server_port
         ))
         .events(tauri_specta::collect_events!(
             BestMovesPayload,

--- a/src-tauri/src/sound.rs
+++ b/src-tauri/src/sound.rs
@@ -1,0 +1,144 @@
+#[cfg(target_os = "linux")]
+use once_cell::sync::OnceCell;
+
+#[cfg(target_os = "linux")]
+static SOUND_SERVER_PORT: OnceCell<u16> = OnceCell::new();
+
+#[cfg(target_os = "linux")]
+pub fn start_sound_server(
+    resource_dir: std::path::PathBuf,
+) -> Result<u16, Box<dyn std::error::Error>> {
+    use axum::{extract, routing::get, Router};
+    use std::sync::Arc;
+
+    let listener = std::net::TcpListener::bind("127.0.0.1:0")?;
+    let port = listener.local_addr()?.port();
+    SOUND_SERVER_PORT
+        .set(port)
+        .map_err(|_| "Sound server port already set")?;
+
+    let sound_dir = Arc::new(resource_dir.join("sound"));
+
+    let app = Router::new()
+        .route("/sound/*path", get(serve_sound))
+        .layer(extract::Extension(sound_dir));
+
+    tokio::spawn(async move {
+        let server = axum::Server::from_tcp(listener)
+            .expect("Failed to create sound server from TCP listener")
+            .serve(app.into_make_service());
+        if let Err(e) = server.await {
+            log::error!("Sound server error: {}", e);
+        }
+    });
+
+    log::info!("Sound server started on port {}", port);
+    Ok(port)
+}
+
+#[cfg(target_os = "linux")]
+async fn serve_sound(
+    axum::extract::Extension(sound_dir): axum::extract::Extension<
+        std::sync::Arc<std::path::PathBuf>,
+    >,
+    axum::extract::Path(path): axum::extract::Path<String>,
+    headers: axum::http::HeaderMap,
+) -> axum::response::Response {
+    use axum::http::{header, StatusCode};
+    use axum::response::IntoResponse;
+
+    let path = path.strip_prefix('/').unwrap_or(&path);
+
+    if path.contains("..") {
+        return StatusCode::FORBIDDEN.into_response();
+    }
+
+    let file_path = sound_dir.join(path);
+
+    if let (Ok(canonical_file), Ok(canonical_dir)) =
+        (file_path.canonicalize(), sound_dir.canonicalize())
+    {
+        if !canonical_file.starts_with(&canonical_dir) {
+            return StatusCode::FORBIDDEN.into_response();
+        }
+    }
+
+    let data = match tokio::fs::read(&file_path).await {
+        Ok(d) => d,
+        Err(_) => return StatusCode::NOT_FOUND.into_response(),
+    };
+
+    let total_size = data.len();
+    let content_type = if path.ends_with(".mp3") {
+        "audio/mpeg"
+    } else if path.ends_with(".ogg") {
+        "audio/ogg"
+    } else if path.ends_with(".wav") {
+        "audio/wav"
+    } else if path.ends_with(".flac") {
+        "audio/flac"
+    } else {
+        "application/octet-stream"
+    };
+
+    if let Some(range_value) = headers.get(header::RANGE) {
+        if let Ok(range_str) = range_value.to_str() {
+            if let Some((start, end)) = parse_range(range_str, total_size) {
+                let chunk = data[start..=end].to_vec();
+                let mut h = axum::http::HeaderMap::new();
+                h.insert(header::CONTENT_TYPE, content_type.parse().unwrap());
+                h.insert(header::ACCEPT_RANGES, "bytes".parse().unwrap());
+                h.insert(
+                    header::CONTENT_RANGE,
+                    format!("bytes {}-{}/{}", start, end, total_size)
+                        .parse()
+                        .unwrap(),
+                );
+                h.insert(
+                    header::CONTENT_LENGTH,
+                    chunk.len().to_string().parse().unwrap(),
+                );
+                return (StatusCode::PARTIAL_CONTENT, h, chunk).into_response();
+            }
+        }
+    }
+
+    let mut h = axum::http::HeaderMap::new();
+    h.insert(header::CONTENT_TYPE, content_type.parse().unwrap());
+    h.insert(header::ACCEPT_RANGES, "bytes".parse().unwrap());
+    h.insert(
+        header::CONTENT_LENGTH,
+        total_size.to_string().parse().unwrap(),
+    );
+    (StatusCode::OK, h, data).into_response()
+}
+
+#[cfg(target_os = "linux")]
+fn parse_range(range: &str, total_size: usize) -> Option<(usize, usize)> {
+    let range = range.strip_prefix("bytes=")?;
+    let mut parts = range.splitn(2, '-');
+    let start: usize = parts.next()?.parse().ok()?;
+    let end_str = parts.next()?;
+    let end: usize = if end_str.is_empty() {
+        total_size.checked_sub(1)?
+    } else {
+        end_str.parse().ok()?
+    };
+    if start > end || end >= total_size {
+        return None;
+    }
+    Some((start, end))
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn get_sound_server_port() -> u16 {
+    #[cfg(target_os = "linux")]
+    {
+        *SOUND_SERVER_PORT.get().unwrap_or(&0)
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        0
+    }
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -89,7 +89,7 @@
         ],
         "enable": true
       },
-      "csp": "default-src 'self'; img-src 'self' asset: data: blob: https:; media-src 'self' asset:; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self' https://github.com"
+      "csp": "default-src 'self'; img-src 'self' asset: data: blob: https:; media-src 'self' asset: http://127.0.0.1:*; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self' https://github.com http://127.0.0.1:*"
     }
   }
 }

--- a/src/bindings/generated.ts
+++ b/src/bindings/generated.ts
@@ -568,6 +568,9 @@ async openExternalLink(url: string) : Promise<Result<null, string>> {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
 }
+},
+async getSoundServerPort() : Promise<number> {
+    return await TAURI_INVOKE("get_sound_server_port");
 }
 }
 

--- a/src/utils/sound.ts
+++ b/src/utils/sound.ts
@@ -1,9 +1,15 @@
-import { convertFileSrc } from "@tauri-apps/api/core";
+import { convertFileSrc, invoke } from "@tauri-apps/api/core";
 import { resolveResource } from "@tauri-apps/api/path";
+import { platform } from "@tauri-apps/plugin-os";
 import { getDefaultStore } from "jotai";
 import { soundCollectionAtom, soundVolumeAtom } from "@/state/atoms";
 
 let lastTime = 0;
+
+const isLinux = platform() === "linux";
+const soundServerPort: Promise<number> = isLinux
+  ? invoke<number>("get_sound_server_port")
+  : Promise.resolve(0);
 
 export async function playSound(capture: boolean, check: boolean) {
   const now = Date.now();
@@ -27,13 +33,20 @@ export async function playSound(capture: boolean, check: boolean) {
   const path = `sound/${collection}/${type}.mp3`;
 
   try {
-    const filePath = await resolveResource(path);
-    const assetUrl = convertFileSrc(filePath);
-    
+    let audioSrc: string;
+
+    if (isLinux) {
+      const port = await soundServerPort;
+      audioSrc = `http://127.0.0.1:${port}/${path}`;
+    } else {
+      const filePath = await resolveResource(path);
+      audioSrc = convertFileSrc(filePath);
+    }
+
     const audio = new Audio();
     audio.volume = volume;
-    audio.src = assetUrl;
-    
+    audio.src = audioSrc;
+
     await audio.play();
   } catch (error) {
     if (import.meta.env.DEV) {


### PR DESCRIPTION
- Tauri's asset: protocol doesn't support <audio> playback on Linux yet (WebKitGTK limitation). This adds a
local HTTP sound server as a workaround that serves audio files from the bundled resources on 127.0.0.1
with a random port.
- On macOS/Windows, audio playback continues to use convertFileSrc / asset: protocol as before.

Changes

Backend (Rust):
- New sound.rs module - spins up a lightweight Axum HTTP server on Linux at startup, bound to
127.0.0.1:0 (OS-assigned port). Serves sound files from the resource directory with proper Content-Type
headers and HTTP range request support. Includes path traversal protection.
- get_sound_server_port Tauri command exposed via specta so the frontend can discover the port.
- Linux platform init (linux.rs) now receives the app handle to access the resource directory and start
the sound server.

Frontend (TypeScript):
- sound.ts detects Linux at module load and fetches the sound server port.
- On Linux, audio src is set to http://127.0.0.1:{port}/sound/... instead of asset://.

Config:
- CSP updated to allow media-src and connect-src from http://127.0.0.1:*.

Fixes: #258