### PR TITLE
fix: compress persisted tab state to avoid sessionStorage quota overflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "i18next": "^26.0.10",
     "immer": "^11.1.8",
     "jotai": "^2.20.0",
+    "lz-string": "^1.5.0",
     "mantine-contextmenu": "^8.3.13",
     "mantine-datatable": "^8.3.13",
     "mantine-flagpack": "^4.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,6 +149,9 @@ importers:
       jotai:
         specifier: ^2.20.0
         version: 2.20.0(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@19.2.14)(react@19.2.6)
+      lz-string:
+        specifier: ^1.5.0
+        version: 1.5.0
       mantine-contextmenu:
         specifier: ^8.3.13
         version: 8.3.13(@mantine/core@9.1.1(@mantine/hooks@9.1.1(react@19.2.6))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@mantine/hooks@9.1.1(react@19.2.6))(clsx@2.1.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -2778,6 +2781,10 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -5896,6 +5903,8 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lz-string@1.5.0: {}
 
   magic-string@0.30.21:
     dependencies:

--- a/src/features/boards/components/BoardGame.tsx
+++ b/src/features/boards/components/BoardGame.tsx
@@ -80,10 +80,16 @@ import type { TimeControlField } from "@/utils/clock";
 import { getDocumentDir } from "@/utils/documentDir";
 import type { LocalEngine } from "@/utils/engines";
 import { createFile } from "@/utils/files";
+import { deserializeStorageValue } from "@/utils/tabStateStorage";
 import { formatDateToPGN } from "@/utils/format";
 import { type GameRecord, saveGameRecord } from "@/utils/gameRecords";
 import { createTab } from "@/utils/tabs";
-import { type GameHeaders, type TreeNode, treeIteratorMainLine } from "@/utils/treeReducer";
+import {
+  type GameHeaders,
+  type TreeNode,
+  type TreeState,
+  treeIteratorMainLine,
+} from "@/utils/treeReducer";
 import GameNotationWrapper from "./GameNotationWrapper";
 import ResponsiveBoard from "./ResponsiveBoard";
 
@@ -1282,7 +1288,9 @@ function BoardGame() {
       try {
         const tabStateJson = sessionStorage.getItem(newTabId);
         if (tabStateJson) {
-          const tabState = JSON.parse(tabStateJson);
+          const tabState = deserializeStorageValue<{ version: number; state: TreeState }>(
+            tabStateJson,
+          );
           if (tabState?.state) {
             const treeState = tabState.state;
 

--- a/src/features/boards/components/ImportModal.tsx
+++ b/src/features/boards/components/ImportModal.tsx
@@ -24,6 +24,7 @@ import { chessopsError } from "@/utils/chessops";
 import { createFile, createTempImportFile, openFile } from "@/utils/files";
 import { getLichessGame } from "@/utils/lichess/api";
 import { parseMultiplePgnGames } from "@/utils/pgnUtils";
+import { serializeStorageValue } from "@/utils/tabStateStorage";
 import { defaultTree, getGameName, type TreeState } from "@/utils/treeReducer";
 import { ImportSummary } from "./ImportSummary";
 
@@ -305,7 +306,11 @@ export default function ImportModal({ context, id }: ContextModalProps<{ modalBo
       }
       const tree = await parsePGN(pgn);
       setCurrentTab((prev) => {
-        sessionStorage.setItem(prev.value, JSON.stringify({ version: 0, state: tree }));
+        try {
+          sessionStorage.setItem(prev.value, serializeStorageValue({ version: 0, state: tree }));
+        } catch (e) {
+          setError(e instanceof Error ? e.message : String(e));
+        }
         return {
           ...prev,
           name: getGameName(tree.headers),
@@ -324,7 +329,11 @@ export default function ImportModal({ context, id }: ContextModalProps<{ modalBo
       setCurrentTab((prev) => {
         const tree = defaultTree(parsedFen);
         tree.headers.fen = parsedFen;
-        sessionStorage.setItem(prev.value, JSON.stringify({ version: 0, state: tree }));
+        try {
+          sessionStorage.setItem(prev.value, serializeStorageValue({ version: 0, state: tree }));
+        } catch (e) {
+          setError(e instanceof Error ? e.message : String(e));
+        }
         return {
           ...prev,
           name: t("features.tabs.analysisBoard.title"),

--- a/src/features/boards/hooks/useTabManagement.tsx
+++ b/src/features/boards/hooks/useTabManagement.tsx
@@ -11,6 +11,7 @@ import { TreeStateContext } from "@/components/TreeStateContext";
 import { MAX_TABS } from "@/features/boards/constants";
 import { activeTabAtom, currentTabAtom, tabsAtom } from "@/state/atoms";
 import { keyMapAtom } from "@/state/keybindings";
+import { deserializeStorageValue } from "@/utils/tabStateStorage";
 import { createTab, genID, saveToFile } from "@/utils/tabs";
 import { unwrap } from "@/utils/unwrap";
 
@@ -33,7 +34,9 @@ function getTabState(tabId: string): { version: number; state: { dirty?: boolean
       return null;
     }
 
-    const parsedState = JSON.parse(rawState);
+    const parsedState = deserializeStorageValue<{ version: number; state: { dirty?: boolean } }>(
+      rawState,
+    );
 
     if (isValidTabState(parsedState)) {
       return parsedState;

--- a/src/state/store/tree.ts
+++ b/src/state/store/tree.ts
@@ -12,6 +12,7 @@ import { parseSanOrUci, positionFromFen } from "@/utils/chessops";
 import { isPrefix } from "@/utils/misc";
 import { getAnnotation } from "@/utils/score";
 import { playSound } from "@/utils/sound";
+import { compressedSessionStorage } from "@/utils/tabStateStorage";
 import {
     createNode,
     defaultTree,
@@ -510,7 +511,7 @@ export const createTreeStore = (id?: string, initialTree?: TreeState) => {
         return createStore<TreeStoreState>()(
             persist(stateCreator, {
                 name: id,
-                storage: createJSONStorage(() => sessionStorage),
+                storage: createJSONStorage(() => compressedSessionStorage),
             }),
         );
     }

--- a/src/utils/__tests__/tabStateStorage.test.ts
+++ b/src/utils/__tests__/tabStateStorage.test.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "vitest";
+import {
+    compressedSessionStorage,
+    deserializeStorageValue,
+    serializeStorageValue,
+} from "../tabStateStorage";
+
+test("round-trips a tab-state envelope", () => {
+    const value = { version: 0, state: { dirty: false, root: { san: null, children: [] } } };
+    expect(deserializeStorageValue(serializeStorageValue(value))).toEqual(value);
+});
+
+test("compresses a large repetitive tree well under its raw JSON size", () => {
+    const big = {
+        version: 0,
+        state: {
+            nodes: Array.from({ length: 20000 }, () => ({
+                san: "Nf3",
+                fen: "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+                comment: "",
+            })),
+        },
+    };
+    const raw = JSON.stringify(big);
+    const compressed = serializeStorageValue(big);
+    expect(raw.length).toBeGreaterThan(1_000_000);
+    expect(compressed.length).toBeLessThan(raw.length / 3);
+});
+
+test("reads back legacy uncompressed JSON and returns null on garbage", () => {
+    const legacy = JSON.stringify({ version: 0, state: { dirty: true } });
+    expect(deserializeStorageValue(legacy)).toEqual({ version: 0, state: { dirty: true } });
+    expect(deserializeStorageValue(" not-valid ")).toBeNull();
+});
+
+test("compressedSessionStorage compresses into sessionStorage and reads it (and legacy) back", () => {
+    sessionStorage.clear();
+    const json = JSON.stringify({ state: { a: 1 }, version: 0 });
+    compressedSessionStorage.setItem("k", json);
+    expect(sessionStorage.getItem("k")).not.toContain('"a"'); // stored compressed
+    expect(compressedSessionStorage.getItem("k")).toBe(json); // round-trips
+    sessionStorage.setItem("legacy", json); // legacy uncompressed
+    expect(compressedSessionStorage.getItem("legacy")).toBe(json);
+});

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -8,6 +8,7 @@ import { commands } from "@/bindings";
 import type { FileMetadata } from "@/features/files/utils/file";
 import { unwrap } from "@/utils/unwrap";
 import { parsePGN } from "./chess";
+import { serializeStorageValue } from "./tabStateStorage";
 import { createTab, type Tab } from "./tabs";
 import { getGameName } from "./treeReducer";
 
@@ -83,13 +84,7 @@ export async function openFile(
 
     // Store the first game's state in session storage (for backward compatibility)
     // The analysis board will handle multiple games through the pgn content
-    sessionStorage.setItem(
-        tabId,
-        JSON.stringify({
-            version: 0,
-            state: firstGameTree,
-        }),
-    );
+    sessionStorage.setItem(tabId, serializeStorageValue({ version: 0, state: firstGameTree }));
 }
 
 export async function createFile({

--- a/src/utils/tabStateStorage.ts
+++ b/src/utils/tabStateStorage.ts
@@ -1,0 +1,53 @@
+import { compressToUTF16, decompressFromUTF16 } from "lz-string";
+import type { StateStorage } from "zustand/middleware";
+
+// Tab/tree state is persisted to sessionStorage, which has a ~5MB quota (UTF-16, ~2 bytes/char).
+// Large opening repertoires serialize to well over 1MB of JSON, so a few open tabs overflow the
+// quota and `setItem` throws. Compress on write (~5x on repetitive chess data) to stay under the
+// quota, and decode on read while tolerating any legacy, uncompressed value already in storage.
+
+export function serializeStorageValue(value: unknown): string {
+    return compressToUTF16(JSON.stringify(value));
+}
+
+export function deserializeStorageValue<T>(raw: string): T | null {
+    try {
+        const decompressed = decompressFromUTF16(raw);
+        if (decompressed) {
+            return JSON.parse(decompressed) as T;
+        }
+    } catch {
+        // Not our compressed format — fall through to legacy plain JSON.
+    }
+    try {
+        return JSON.parse(raw) as T;
+    } catch {
+        return null;
+    }
+}
+
+// Drop-in StateStorage for zustand `persist`: compresses the JSON string into sessionStorage and
+// decompresses on the way out, tolerating any legacy uncompressed value already stored.
+export const compressedSessionStorage: StateStorage = {
+    getItem: (name) => {
+        const raw = sessionStorage.getItem(name);
+        if (raw == null) return null;
+        try {
+            const decompressed = decompressFromUTF16(raw);
+            // Validate that decompression produced parseable JSON before trusting it.
+            if (decompressed) {
+                JSON.parse(decompressed);
+                return decompressed;
+            }
+        } catch {
+            // Not a valid compressed value — fall through to return the raw string (legacy).
+        }
+        return raw;
+    },
+    setItem: (name, value) => {
+        sessionStorage.setItem(name, compressToUTF16(value));
+    },
+    removeItem: (name) => {
+        sessionStorage.removeItem(name);
+    },
+};

--- a/src/utils/tabs.ts
+++ b/src/utils/tabs.ts
@@ -3,6 +3,7 @@ import { INITIAL_FEN } from "chessops/fen";
 import { z } from "zod";
 import type { StoreApi } from "zustand";
 import { commands } from "@/bindings";
+import { serializeStorageValue } from "./tabStateStorage";
 import { fileMetadataSchema } from "@/features/files/utils/file";
 import type { TreeStoreState } from "@/state/store/tree";
 import { createFile, getFileNameWithoutExtension, isTempImportFile } from "@/utils/files";
@@ -112,7 +113,7 @@ export async function createTab({
                 tree.position = position;
             }
         }
-        sessionStorage.setItem(id, JSON.stringify({ version: 0, state: tree }));
+        sessionStorage.setItem(id, serializeStorageValue({ version: 0, state: tree }));
     }
 
     setTabs((prev) => {
@@ -361,7 +362,7 @@ export async function reloadTab(tab: Tab): Promise<TreeState | undefined> {
     }
 
     if (tree != null) {
-        sessionStorage.setItem(tab.value, JSON.stringify({ version: 0, state: tree }));
+        sessionStorage.setItem(tab.value, serializeStorageValue({ version: 0, state: tree }));
         return tree;
     }
 }


### PR DESCRIPTION
## Description

Each open tab persists its full game tree to `sessionStorage`. With a large tree — on the order of thousands of half-moves spread across hundreds of variation lines — the serialized JSON exceeds the browser's ~5 MB `sessionStorage` quota. The write throws `QuotaExceededError`, which showed up as the import flow silently failing (short spinner, then the button resets and no tab opens) and tab state not persisting across reloads.

This compresses the persisted value before writing and decompresses on read, using `lz-string` (UTF-16):

- `src/utils/tabStateStorage.ts` — `serializeStorageValue` / `deserializeStorageValue` helpers plus a `compressedSessionStorage` `StateStorage` adapter for the tab-tree store.
- Reads fall back to legacy plain-JSON values, so tabs persisted before this change keep loading after the upgrade.
- The import modal's link/FEN writes are wrapped so a quota failure surfaces an error to the user instead of failing silently.

Compression brings a multi-megabyte tree comfortably back under the quota.

## How This Was Tested
- [x] Development testing completed
- [x] Built successfully

**Tested on:** macOS (`pnpm tauri dev`; `tsgo --noEmit && vite build` green)

- Imported a large multi-variation PGN that previously overflowed the quota: it now imports and opens, and three such tabs persist and restore across reloads.
- Added unit tests for the serialize/deserialize round-trip and the legacy plain-JSON fallback (`src/utils/__tests__/tabStateStorage.test.ts`).

## Screenshots / Additional Context

The full notation test suite stays green; this change only adds passing tests.

## Checklist
- [x] Followed contributing guidelines
- [x] Reviewed code for style and correctness
