### PR TITLE
fix: open file navigates to the board view

### DIFF
--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -157,8 +157,8 @@ function RootLayout() {
       });
 
       if (typeof selected === "string") {
-        navigate({ to: "/" });
-        openFile(selected, setTabs, setActiveTab);
+        await openFile(selected, setTabs, setActiveTab);
+        navigate({ to: "/boards" });
       }
     } catch (error) {
       console.error("Failed to open file:", error);


### PR DESCRIPTION
## Description

Opening a PGN through **File → Open** loads the game into a new tab but then navigates to `/`. When "show dashboard on startup" is enabled, `/` renders the dashboard rather than the board, so the freshly-opened game sits on a background tab and the user is left on the dashboard — it looks like nothing happened until you manually click "Board" in the sidebar.

This awaits `openFile` (so the tab exists first) and then navigates to `/boards`, so the opened game is shown immediately regardless of the startup-page setting.

## How This Was Tested
- [x] Development testing completed
- [x] Built successfully

**Tested on:** macOS (`pnpm tauri dev`; `tsgo --noEmit && vite build` green)

File → Open now lands directly on the board showing the opened game, instead of staying on the dashboard.

## Checklist
- [x] Followed contributing guidelines
- [x] Reviewed code for style and correctness
