### PR TITLE
feat: fork chooser to pick continuations at branch points

### DIFF
--- a/src/components/ForkChooser.css.ts
+++ b/src/components/ForkChooser.css.ts
@@ -1,0 +1,94 @@
+import { style } from "@vanilla-extract/css";
+
+export const pop = style({
+    position: "fixed",
+    zIndex: 300,
+    width: 214,
+    background: "var(--mantine-color-body)",
+    border: "1px solid var(--mantine-color-default-border)",
+    borderRadius: "var(--mantine-radius-md)",
+    boxShadow: "var(--mantine-shadow-xl)",
+    overflow: "hidden",
+    display: "flex",
+    flexDirection: "column",
+    transition: "opacity 0.12s ease",
+    fontSize: 14,
+});
+
+export const header = style({
+    padding: "8px 12px",
+    fontSize: 12,
+    fontWeight: 600,
+    color: "var(--mantine-color-dimmed)",
+    borderBottom: "1px solid var(--mantine-color-default-border)",
+});
+
+export const rows = style({
+    padding: 5,
+    display: "flex",
+    flexDirection: "column",
+    gap: 2,
+    flex: 1,
+    minHeight: 0,
+    overflowY: "auto",
+});
+
+export const row = style({
+    display: "flex",
+    alignItems: "center",
+    gap: 10,
+    padding: "7px 9px",
+    borderRadius: "var(--mantine-radius-sm)",
+    background: "transparent",
+    border: "1px solid transparent",
+    cursor: "pointer",
+    textAlign: "left",
+    width: "100%",
+    color: "var(--mantine-color-text)",
+    font: "inherit",
+    selectors: {
+        "&:hover": {
+            background: "var(--mantine-color-default-hover)",
+        },
+    },
+});
+
+export const selected = style({
+    background: "var(--mantine-primary-color-light)",
+    borderColor: "var(--mantine-primary-color-filled)",
+    selectors: {
+        "&:hover": {
+            background: "var(--mantine-primary-color-light)",
+        },
+    },
+});
+
+export const idx = style({
+    fontSize: 11,
+    color: "var(--mantine-color-dimmed)",
+    minWidth: 12,
+    textAlign: "center",
+});
+
+export const san = style({
+    fontWeight: 600,
+});
+
+export const nag = style({
+    fontWeight: 800,
+});
+
+export const main = style({
+    marginLeft: "auto",
+    fontSize: 9,
+    letterSpacing: "0.08em",
+    textTransform: "uppercase",
+    color: "var(--mantine-color-dimmed)",
+});
+
+export const footer = style({
+    padding: "7px 12px",
+    fontSize: 11,
+    color: "var(--mantine-color-dimmed)",
+    borderTop: "1px solid var(--mantine-color-default-border)",
+});

--- a/src/components/ForkChooser.tsx
+++ b/src/components/ForkChooser.tsx
@@ -1,0 +1,207 @@
+import { Portal, useMantineTheme } from "@mantine/core";
+import { useAtomValue } from "jotai";
+import { useContext, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useStore } from "zustand";
+import { TreeStateContext } from "@/components/TreeStateContext";
+import { forkChooserAutoAtom } from "@/state/atoms";
+import { ANNOTATION_INFO } from "@/utils/annotation";
+import { cycleIndex, followPath, forkCandidates, shouldAutoOpen } from "@/utils/forkChooser";
+import * as classes from "./ForkChooser.css";
+
+// Anchored, portaled popover that lists the continuations at a fork. It mounts/unmounts only —
+// it never participates in the notation panel's layout, so the move list, comments, and board
+// are never re-laid-out when it appears.
+export default function ForkChooser({
+  parentRef,
+}: {
+  parentRef: { current: HTMLDivElement | null };
+}) {
+  const store = useContext(TreeStateContext)!;
+  const root = useStore(store, (s) => s.root);
+  const position = useStore(store, (s) => s.position);
+  const goToMove = useStore(store, (s) => s.goToMove);
+  const autoEnabled = useAtomValue(forkChooserAutoAtom);
+  const theme = useMantineTheme();
+  const { t } = useTranslation();
+
+  const candidates = forkCandidates(root, position);
+  const posKey = position.join(",");
+  const [selected, setSelected] = useState(0);
+  const selectedRef = useRef(0);
+  const [dismissed, setDismissed] = useState<string | null>(null);
+  const [coords, setCoords] = useState<{ top: number; left: number; maxH: number } | null>(null);
+  const popRef = useRef<HTMLDivElement>(null);
+  const rowsRef = useRef<HTMLDivElement>(null);
+
+  const open = shouldAutoOpen({
+    candidateCount: candidates.length,
+    autoEnabled,
+    // PA has no per-tree practice path; the Practice/train feature does not use this notation
+    // panel, so the chooser cannot appear mid-drill and this gate is always satisfied here.
+    practiceActive: false,
+    dismissed: dismissed === posKey,
+  });
+
+  // Reset selection + un-dismiss whenever we move to a different position.
+  useEffect(() => {
+    selectedRef.current = 0;
+    setSelected(0);
+    setDismissed(null);
+  }, [posKey]);
+
+  // Position the card under (or above) the current-move cell, following any scroll.
+  useLayoutEffect(() => {
+    if (!open) {
+      setCoords(null);
+      return;
+    }
+    const reposition = () => {
+      const anchor = parentRef.current?.querySelector("[data-current-move]") as HTMLElement | null;
+      if (!anchor) {
+        setCoords(null);
+        return;
+      }
+      const r = anchor.getBoundingClientRect();
+      const gap = 6;
+      const margin = 8;
+      const popW = 214;
+      const desired = 320;
+      // Adapt the height to the room around the move so a long list never flips into a tall block
+      // that covers unrelated panels — it opens snug to the move and scrolls inside instead.
+      const spaceBelow = window.innerHeight - r.bottom - gap - margin;
+      const spaceAbove = r.top - gap - margin;
+      let top: number;
+      let maxH: number;
+      if (spaceBelow >= 90 || spaceBelow >= spaceAbove) {
+        top = r.bottom + gap;
+        maxH = Math.max(90, Math.min(desired, spaceBelow));
+      } else {
+        maxH = Math.max(90, Math.min(desired, spaceAbove));
+        top = r.top - gap - maxH;
+      }
+      let left = r.left;
+      if (left + popW > window.innerWidth - margin) left = window.innerWidth - margin - popW;
+      if (left < margin) left = margin;
+      setCoords({ top, left, maxH });
+    };
+    reposition();
+    const viewport = parentRef.current;
+    window.addEventListener("scroll", reposition, true);
+    window.addEventListener("resize", reposition);
+    viewport?.addEventListener("scroll", reposition);
+    return () => {
+      window.removeEventListener("scroll", reposition, true);
+      window.removeEventListener("resize", reposition);
+      viewport?.removeEventListener("scroll", reposition);
+    };
+  }, [open, posKey, candidates.length, parentRef]);
+
+  // Keyboard. Capture-phase + stopPropagation so we preempt the global move-navigation hotkeys
+  // (arrows / branch keys) and the annotation digit keys while the chooser is open.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      const tgt = e.target as HTMLElement | null;
+      if (tgt && (/^(INPUT|TEXTAREA|SELECT)$/.test(tgt.tagName) || tgt.isContentEditable)) return;
+      if (e.key === "ArrowDown") {
+        selectedRef.current = cycleIndex(selectedRef.current, candidates.length, 1);
+        setSelected(selectedRef.current);
+        e.preventDefault();
+        e.stopPropagation();
+      } else if (e.key === "ArrowUp") {
+        selectedRef.current = cycleIndex(selectedRef.current, candidates.length, -1);
+        setSelected(selectedRef.current);
+        e.preventDefault();
+        e.stopPropagation();
+      } else if (e.key === "ArrowRight" || e.key === "Enter") {
+        goToMove(followPath(position, selectedRef.current));
+        e.preventDefault();
+        e.stopPropagation();
+      } else if (e.key === "Escape") {
+        setDismissed(posKey);
+        e.preventDefault();
+        e.stopPropagation();
+      } else if (/^[1-9]$/.test(e.key)) {
+        const i = Number(e.key) - 1;
+        if (i < candidates.length) {
+          goToMove(followPath(position, i));
+          e.preventDefault();
+          e.stopPropagation();
+        }
+      }
+    };
+    window.addEventListener("keydown", onKey, { capture: true });
+    return () => window.removeEventListener("keydown", onKey, { capture: true });
+  }, [open, candidates.length, posKey, position, goToMove]);
+
+  // Clicking anywhere outside the card dismisses it (until the next move).
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (popRef.current && !popRef.current.contains(e.target as Node)) setDismissed(posKey);
+    };
+    window.addEventListener("mousedown", onDown);
+    return () => window.removeEventListener("mousedown", onDown);
+  }, [open, posKey]);
+
+  // Keep the highlighted row visible inside the (possibly scrolling) list.
+  useEffect(() => {
+    if (!open) return;
+    const el = rowsRef.current?.children[selected] as HTMLElement | undefined;
+    el?.scrollIntoView({ block: "nearest" });
+  }, [selected, open]);
+
+  if (!open) return null;
+
+  return (
+    <Portal>
+      <div
+        ref={popRef}
+        className={classes.pop}
+        style={{
+          top: coords?.top ?? -9999,
+          left: coords?.left ?? -9999,
+          maxHeight: coords?.maxH,
+          opacity: coords ? 1 : 0,
+        }}
+      >
+        <div className={classes.header}>{t("forkChooser.replies", { n: candidates.length })}</div>
+        <div className={classes.rows} ref={rowsRef}>
+          {candidates.map((child, i) => {
+            const ann = child.annotations[0] ?? "";
+            const colorName = ANNOTATION_INFO[ann]?.color;
+            const glyphColor =
+              colorName && colorName !== "gray" ? theme.colors[colorName][6] : undefined;
+            const moveText = t("formatters.moveNotation", { move: child.san ?? "" });
+            return (
+              <button
+                type="button"
+                key={`${i}-${child.san ?? ""}`}
+                className={`${classes.row} ${i === selected ? classes.selected : ""}`}
+                // mousemove (not mouseenter) so the popover opening under a stationary cursor
+                // doesn't hijack the default highlight — only real cursor movement re-selects.
+                onMouseMove={() => {
+                  if (selectedRef.current === i) return;
+                  selectedRef.current = i;
+                  setSelected(i);
+                }}
+                onClick={() => goToMove(followPath(position, i))}
+              >
+                <span className={classes.idx}>{i + 1}</span>
+                <span className={classes.san}>{moveText}</span>
+                {ann && (
+                  <span className={classes.nag} style={{ color: glyphColor }}>
+                    {ann}
+                  </span>
+                )}
+                {i === 0 && <span className={classes.main}>{t("forkChooser.main")}</span>}
+              </button>
+            );
+          })}
+        </div>
+        <div className={classes.footer}>↑ ↓ · ↵ · esc</div>
+      </div>
+    </Portal>
+  );
+}

--- a/src/components/ForkChooser.tsx
+++ b/src/components/ForkChooser.tsx
@@ -1,12 +1,13 @@
 import { Portal, useMantineTheme } from "@mantine/core";
 import { useAtomValue } from "jotai";
-import { useContext, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useCallback, useContext, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useStore } from "zustand";
 import { TreeStateContext } from "@/components/TreeStateContext";
 import { forkChooserAutoAtom } from "@/state/atoms";
 import { ANNOTATION_INFO } from "@/utils/annotation";
 import { cycleIndex, followPath, forkCandidates, shouldAutoOpen } from "@/utils/forkChooser";
+import type { NotationViewMode } from "@/utils/notationFlatten";
 import * as classes from "./ForkChooser.css";
 
 // Anchored, portaled popover that lists the continuations at a fork. It mounts/unmounts only —
@@ -14,8 +15,12 @@ import * as classes from "./ForkChooser.css";
 // are never re-laid-out when it appears.
 export default function ForkChooser({
   parentRef,
+  mode,
+  setMode,
 }: {
   parentRef: { current: HTMLDivElement | null };
+  mode: NotationViewMode;
+  setMode?: (mode: NotationViewMode) => void;
 }) {
   const store = useContext(TreeStateContext)!;
   const root = useStore(store, (s) => s.root);
@@ -42,6 +47,16 @@ export default function ForkChooser({
     practiceActive: false,
     dismissed: dismissed === posKey,
   });
+
+  // Follow child `i`. In mainline view, picking a side line (index >= 1) would land on a move the
+  // mainline-only list can't render, so switch to variations view first to keep it visible.
+  const follow = useCallback(
+    (i: number) => {
+      if (mode === "mainline" && i >= 1) setMode?.("variations");
+      goToMove(followPath(position, i));
+    },
+    [mode, setMode, goToMove, position],
+  );
 
   // Reset selection + un-dismiss whenever we move to a different position.
   useEffect(() => {
@@ -115,7 +130,7 @@ export default function ForkChooser({
         e.preventDefault();
         e.stopPropagation();
       } else if (e.key === "ArrowRight" || e.key === "Enter") {
-        goToMove(followPath(position, selectedRef.current));
+        follow(selectedRef.current);
         e.preventDefault();
         e.stopPropagation();
       } else if (e.key === "Escape") {
@@ -125,7 +140,7 @@ export default function ForkChooser({
       } else if (/^[1-9]$/.test(e.key)) {
         const i = Number(e.key) - 1;
         if (i < candidates.length) {
-          goToMove(followPath(position, i));
+          follow(i);
           e.preventDefault();
           e.stopPropagation();
         }
@@ -133,7 +148,7 @@ export default function ForkChooser({
     };
     window.addEventListener("keydown", onKey, { capture: true });
     return () => window.removeEventListener("keydown", onKey, { capture: true });
-  }, [open, candidates.length, posKey, position, goToMove]);
+  }, [open, candidates.length, posKey, follow]);
 
   // Clicking anywhere outside the card dismisses it (until the next move).
   useEffect(() => {
@@ -186,7 +201,7 @@ export default function ForkChooser({
                   selectedRef.current = i;
                   setSelected(i);
                 }}
-                onClick={() => goToMove(followPath(position, i))}
+                onClick={() => follow(i)}
               >
                 <span className={classes.idx}>{i + 1}</span>
                 <span className={classes.san}>{moveText}</span>

--- a/src/components/GameNotation.tsx
+++ b/src/components/GameNotation.tsx
@@ -34,10 +34,12 @@ function GameNotation({
   }
 
   const [invisibleValue, setInvisible] = useAtom(currentInvisibleAtom);
-  const [variationState, toggleVariationState] = useToggle([
+  const [variationState, setVariationState] = useToggle([
     initialVariationState,
     ...["mainline", "variations", "repertoire"].filter((v) => v !== initialVariationState),
-  ]) as [VariationState, () => void];
+  ]) as [VariationState, (value?: VariationState) => void];
+  // The header button cycles modes; the fork chooser sets a specific mode (see setMode below).
+  const cycleVariationState = () => setVariationState();
   const [showComments, toggleComments] = useToggle([true, false]);
 
   const invisible = topBar && invisibleValue;
@@ -53,14 +55,14 @@ function GameNotation({
             showComments={showComments}
             toggleComments={toggleComments}
             variationState={variationState}
-            toggleVariationState={toggleVariationState}
+            toggleVariationState={cycleVariationState}
           />
         )}
         <VirtualizedNotation
           mode={variationState}
           showComments={showComments}
           invisible={invisible}
-          toggleVariationState={toggleVariationState}
+          setMode={setVariationState}
         />
       </Stack>
     </Paper>

--- a/src/components/VirtualizedNotation.tsx
+++ b/src/components/VirtualizedNotation.tsx
@@ -173,12 +173,12 @@ function VirtualizedNotation({
   mode,
   showComments,
   invisible,
-  toggleVariationState: _toggleVariationState,
+  setMode,
 }: {
   mode: NotationViewMode;
   showComments: boolean;
   invisible?: boolean;
-  toggleVariationState?: () => void;
+  setMode?: (mode: NotationViewMode) => void;
 }) {
   const store = useContext(TreeStateContext)!;
   const root = useStore(store, (s) => s.root);
@@ -322,7 +322,7 @@ function VirtualizedNotation({
           );
         })}
       </div>
-      <ForkChooser parentRef={parentRef} />
+      <ForkChooser parentRef={parentRef} mode={mode} setMode={setMode} />
     </ScrollArea>
   );
 }

--- a/src/components/VirtualizedNotation.tsx
+++ b/src/components/VirtualizedNotation.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/utils/notationFlatten";
 import { getNodeAtPath } from "@/utils/treeReducer";
 import CompleteMoveCell from "./CompleteMoveCell";
+import ForkChooser from "./ForkChooser";
 import * as styles from "./GameNotation.css";
 
 const MAX_LINE_PLIES = 40;
@@ -321,6 +322,7 @@ function VirtualizedNotation({
           );
         })}
       </div>
+      <ForkChooser parentRef={parentRef} />
     </ScrollArea>
   );
 }

--- a/src/features/settings/SettingsPage.tsx
+++ b/src/features/settings/SettingsPage.tsx
@@ -39,6 +39,7 @@ import {
   enableBoardScrollAtom,
   eraseDrawablesOnClickAtom,
   forcedEnPassantAtom,
+  forkChooserAutoAtom,
   minimumGamesAtom,
   moveInputAtom,
   moveMethodAtom,
@@ -203,6 +204,23 @@ export default function Page() {
               </Text>
             </div>
             <SettingsSwitch atom={showDestsAtom} />
+          </Group>
+        ),
+      },
+      {
+        id: "fork-chooser",
+        title: t("forkChooser.title"),
+        description: t("forkChooser.description"),
+        tab: "board",
+        component: (
+          <Group justify="space-between" wrap="nowrap" gap="xl" className={classes.item}>
+            <div>
+              <Text>{t("forkChooser.title")}</Text>
+              <Text size="xs" c="dimmed">
+                {t("forkChooser.description")}
+              </Text>
+            </div>
+            <SettingsSwitch atom={forkChooserAutoAtom} />
           </Group>
         ),
       },

--- a/src/locales/en-US/common.json
+++ b/src/locales/en-US/common.json
@@ -995,6 +995,12 @@
       "fiftyMoveRule": "*due to the 50-move rule"
     }
   },
+  "forkChooser": {
+    "replies": "{{n}} replies",
+    "main": "main",
+    "title": "Fork chooser",
+    "description": "Show the available continuations in a popup when you reach a branch"
+  },
   "settings": {
     "board": {
       "title": "Board",

--- a/src/state/boardAtoms.ts
+++ b/src/state/boardAtoms.ts
@@ -10,6 +10,7 @@ export const showDestsAtom = atomWithStorage<boolean>("show-dests", true);
 export const snapArrowsAtom = atomWithStorage<boolean>("snap-dests", true);
 export const showArrowsAtom = atomWithStorage<boolean>("show-arrows", true);
 export const showConsecutiveArrowsAtom = atomWithStorage<boolean>("show-consecutive-arrows", false);
+export const forkChooserAutoAtom = atomWithStorage<boolean>("fork-chooser-auto", true);
 export const eraseDrawablesOnClickAtom = atomWithStorage<boolean>(
     "erase-drawables-on-click",
     false,

--- a/src/utils/__tests__/forkChooser.test.ts
+++ b/src/utils/__tests__/forkChooser.test.ts
@@ -1,0 +1,58 @@
+import { expect, test } from "vitest";
+import {
+    cycleIndex,
+    followPath,
+    forkCandidates,
+    isForkPosition,
+    shouldAutoOpen,
+} from "../forkChooser";
+import type { TreeNode } from "../treeReducer";
+
+let fenCounter = 0;
+function mk(san: string | null, children: TreeNode[] = []): TreeNode {
+    fenCounter += 1;
+    return {
+        fen: `fen-${fenCounter}`,
+        san,
+        children,
+        halfMoves: 0,
+        annotations: [],
+        comment: "",
+    } as unknown as TreeNode;
+}
+
+test("forkCandidates returns the children of the node at the position", () => {
+    const root = mk(null, [mk("e4", [mk("e5"), mk("c5"), mk("e6")])]);
+    expect(forkCandidates(root, [0]).map((c) => c.san)).toEqual(["e5", "c5", "e6"]);
+});
+
+test("forkCandidates is empty at a leaf", () => {
+    const root = mk(null, [mk("e4")]);
+    expect(forkCandidates(root, [0])).toEqual([]);
+});
+
+test("isForkPosition is true only with >= 2 children", () => {
+    const root = mk(null, [mk("e4", [mk("e5"), mk("c5")])]);
+    expect(isForkPosition(root, [0])).toBe(true); // e4 has two replies
+    expect(isForkPosition(root, [])).toBe(false); // root has one child
+});
+
+test("cycleIndex wraps in both directions and is safe at length 0", () => {
+    expect(cycleIndex(0, 3, 1)).toBe(1);
+    expect(cycleIndex(2, 3, 1)).toBe(0);
+    expect(cycleIndex(0, 3, -1)).toBe(2);
+    expect(cycleIndex(0, 0, 1)).toBe(0);
+});
+
+test("followPath appends the chosen child index", () => {
+    expect(followPath([0, 1], 2)).toEqual([0, 1, 2]);
+});
+
+test("shouldAutoOpen gates on every condition", () => {
+    const base = { candidateCount: 3, autoEnabled: true, practiceActive: false, dismissed: false };
+    expect(shouldAutoOpen(base)).toBe(true);
+    expect(shouldAutoOpen({ ...base, autoEnabled: false })).toBe(false);
+    expect(shouldAutoOpen({ ...base, practiceActive: true })).toBe(false);
+    expect(shouldAutoOpen({ ...base, dismissed: true })).toBe(false);
+    expect(shouldAutoOpen({ ...base, candidateCount: 1 })).toBe(false);
+});

--- a/src/utils/forkChooser.ts
+++ b/src/utils/forkChooser.ts
@@ -1,0 +1,33 @@
+import { getNodeAtPath, type TreeNode } from "./treeReducer";
+
+/** The children of the node at `position` — i.e. the available continuations. */
+export function forkCandidates(root: TreeNode, position: number[]): TreeNode[] {
+    const node = getNodeAtPath(root, position);
+    return node?.children ?? [];
+}
+
+/** A position is a "fork" when it has more than one continuation. */
+export function isForkPosition(root: TreeNode, position: number[]): boolean {
+    return forkCandidates(root, position).length >= 2;
+}
+
+/** Whether the chooser should auto-open right now. */
+export function shouldAutoOpen(p: {
+    candidateCount: number;
+    autoEnabled: boolean;
+    practiceActive: boolean;
+    dismissed: boolean;
+}): boolean {
+    return p.autoEnabled && !p.practiceActive && !p.dismissed && p.candidateCount >= 2;
+}
+
+/** Move the highlighted index by `delta`, wrapping; safe when `length` is 0. */
+export function cycleIndex(current: number, length: number, delta: number): number {
+    if (length <= 0) return 0;
+    return (current + delta + length) % length;
+}
+
+/** The tree path reached by following child `index` from `position`. */
+export function followPath(position: number[], index: number): number[] {
+    return [...position, index];
+}


### PR DESCRIPTION
## Description

At a branch point (a move with more than one continuation) there is no in-flow way to see the available replies and pick one; stepping forward just takes the first child. This adds a "fork chooser": a small popover that auto-opens at a fork, anchored under the current move, listing every continuation so you can choose which line to follow. It is aimed at studying a repertoire by stepping forward and picking prepared lines.

- Pure branch logic lives in a tested helper, src/utils/forkChooser.ts (fork detection, the candidate list, selection wrap-around, and the auto-open gate).
- src/components/ForkChooser.tsx renders a Portal card positioned from the current-move cell ([data-current-move]). It only mounts and unmounts, so the move list, comments, and board are never re-laid out when it appears.
- Rows reuse the panel's move formatter (figurine or letters) and annotation colors, with a "main" tag on the mainline continuation.
- Keyboard while open (capture phase, so it preempts the global navigation hotkeys): up and down move the highlight, keys 1 to 9 jump to a child, right or enter follow the highlighted one, and esc or a click outside dismisses.
- Pressing right without moving the highlight follows the mainline, so behavior is unchanged for anyone who ignores it.
- New "Fork chooser" setting (Settings, Board tab, on by default) toggles the auto-open.
- When the list is in mainline view, picking a side line switches it to variations view so the chosen move stays visible.

## How This Was Tested
- [x] Development testing completed
- [x] Built successfully

**Tested on:** macOS (pnpm tauri dev; tsgo --noEmit && vite build green)

- Stepped through a large repertoire: the chooser auto-opens at each fork; keyboard and click selection follow the right line; esc and click-away dismiss without moving; and the list, comments, and board do not reflow.
- Verified the auto-switch from mainline to variations view when entering a side line.
- Added unit tests for the branch logic (src/utils/__tests__/forkChooser.test.ts).

## Checklist
- [x] Followed contributing guidelines
- [x] Reviewed code for style and correctness
