### PR TITLE
fix: prevent duplicate games when refreshing chess.com/lichess accounts

### DIFF
--- a/src/features/accounts/components/AccountCard.tsx
+++ b/src/features/accounts/components/AccountCard.tsx
@@ -29,6 +29,7 @@ import {
   IconX,
 } from "@tabler/icons-react";
 import { appDataDir, resolve } from "@tauri-apps/api/path";
+import { exists } from "@tauri-apps/plugin-fs";
 import { error, info } from "@tauri-apps/plugin-log";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -38,6 +39,7 @@ import { useResponsiveLayout } from "@/hooks/useResponsiveLayout";
 import { downloadChessCom } from "@/utils/chess.com/api";
 import { getDatabases, query_games } from "@/utils/db";
 import { capitalize, parseDate } from "@/utils/format";
+import { gameDateToTimestamp } from "@/utils/lastGameDate";
 import { downloadLichess } from "@/utils/lichess/api";
 import type { Session } from "@/utils/session";
 import { unwrap } from "@/utils/unwrap";
@@ -256,8 +258,12 @@ export function AccountCard({
       ? "0"
       : Math.min(100, Math.max(0, (downloadedGames / effectiveTotal) * 100)).toFixed(2);
 
-  async function getLastGameDate({ database: db }: { database: DatabaseInfo }) {
-    const games = await query_games(db.file, {
+  // Cursor for incremental download/import: the timestamp of the newest game
+  // already stored. Derived from the database FILE (not from React state), so a
+  // not-yet-loaded `currentDatabase` can't make it null and trigger a full
+  // re-import of the whole history (which duplicates every game).
+  async function getLastGameDate(dbFile: string): Promise<number | null> {
+    const games = await query_games(dbFile, {
       options: {
         page: 1,
         pageSize: 1,
@@ -266,14 +272,10 @@ export function AccountCard({
         skipCount: false,
       },
     });
-    const count = games.count ?? 0;
-    if (count > 0 && games.data[0].date && games.data[0].time) {
-      const [year, month, day] = games.data[0].date.split(".").map(Number);
-      const [hour, minute, second] = games.data[0].time.split(":").map(Number);
-      const d = Date.UTC(year, month - 1, day, hour, minute, second);
-      return d;
+    if ((games.count ?? 0) === 0) {
+      return null;
     }
-    return null;
+    return gameDateToTimestamp(games.data[0]?.date, games.data[0]?.time);
   }
 
   return (
@@ -502,8 +504,13 @@ export function AccountCard({
                     onClick={async () => {
                       setLoading(true);
                       try {
-                        const lastGameDate = currentDatabase
-                          ? await getLastGameDate({ database: currentDatabase })
+                        const dbPath = await resolve(
+                          await appDataDir(),
+                          "db",
+                          `${title}_${type}.db3`,
+                        );
+                        const lastGameDate = (await exists(dbPath))
+                          ? await getLastGameDate(dbPath)
                           : null;
                         if (type === "lichess") {
                           await downloadLichess(

--- a/src/utils/__tests__/lastGameDate.test.ts
+++ b/src/utils/__tests__/lastGameDate.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "vitest";
+import { gameDateToTimestamp } from "../lastGameDate";
+
+describe("gameDateToTimestamp", () => {
+    test("computes the UTC millisecond timestamp from date and time", () => {
+        expect(gameDateToTimestamp("2026.06.14", "16:33:06")).toBe(
+            Date.UTC(2026, 5, 14, 16, 33, 6),
+        );
+    });
+
+    test("falls back to start of day when the time is missing (never null for a real game)", () => {
+        const expected = Date.UTC(2026, 5, 9, 0, 0, 0);
+        expect(gameDateToTimestamp("2026.06.09", null)).toBe(expected);
+        expect(gameDateToTimestamp("2026.06.09", undefined)).toBe(expected);
+        expect(gameDateToTimestamp("2026.06.09", "")).toBe(expected);
+    });
+
+    test("returns null only when the date is absent or unparseable", () => {
+        expect(gameDateToTimestamp(null, "16:33:06")).toBeNull();
+        expect(gameDateToTimestamp(undefined, "16:33:06")).toBeNull();
+        expect(gameDateToTimestamp("", "16:33:06")).toBeNull();
+        expect(gameDateToTimestamp("not-a-date", "16:33:06")).toBeNull();
+    });
+});

--- a/src/utils/lastGameDate.ts
+++ b/src/utils/lastGameDate.ts
@@ -1,0 +1,22 @@
+/**
+ * Compute the UTC timestamp (in milliseconds) of a game from its stored
+ * `Date` ("YYYY.MM.DD") and `UTCTime` ("HH:MM:SS") fields.
+ *
+ * This value is used as the incremental-download cursor: only games newer than
+ * it are fetched and imported when refreshing an account. A `null` cursor
+ * disables that filter and re-imports the entire history, so this helper only
+ * returns `null` when the date itself is absent/unparseable. A missing time
+ * falls back to the start of the day rather than collapsing the whole result
+ * to `null`.
+ */
+export function gameDateToTimestamp(date?: string | null, time?: string | null): number | null {
+    if (!date) {
+        return null;
+    }
+    const [year, month, day] = date.split(".").map(Number);
+    if (!year || !month || !day) {
+        return null;
+    }
+    const [hour, minute, second] = (time ?? "00:00:00").split(":").map(Number);
+    return Date.UTC(year, month - 1, day, hour || 0, minute || 0, second || 0);
+}


### PR DESCRIPTION
## Description

Refreshing a connected chess.com or Lichess account could silently re-import the player's **entire** game history, duplicating every game already stored for that account.

The "Download games" button computes a `lastGameDate` cursor that is used both to (a) fetch only archives newer than the last stored game and (b) tell the importer to skip games at or before that timestamp. That cursor was read from the `currentDatabase` component state, which is populated asynchronously after the card mounts. If the button is clicked before that state resolves (e.g. shortly after opening the Accounts page on a fresh launch), the cursor is `null`. A `null` cursor makes `downloadChessCom` fetch from `new Date(0)` (i.e. every archive) and starts the importer with no skip filter, so the whole history is re-appended. Since the games table has no uniqueness guarantee, the result is a full set of duplicates.

### Fix

Derive the cursor from the account's database **file** (resolved deterministically when the button is clicked) instead of from component state, and never return `null` when the database actually contains games:

- `getLastGameDate` now takes the database file path and queries it directly, removing the dependency on a possibly-unloaded `currentDatabase`.
- A small pure helper `gameDateToTimestamp(date, time)` returns `null` only when the date itself is absent/unparseable; a missing time falls back to the start of the day rather than collapsing the whole cursor to `null`.
- The download handler resolves `<title>_<type>.db3` and only passes a `null` cursor when that file does not exist (a genuine first import).

This covers both the chess.com and Lichess download paths.

## How This Was Tested
- [x] Development testing completed
- [x] Built successfully

Automated gates pass: `pnpm build-vite` (type-check + production build), `pnpm test` (3 new unit tests for `gameDateToTimestamp`; all suites pass aside from one pre-existing unrelated failure), `pnpm lint`, and formatting on the changed files.

**Tested on:** macOS

## Screenshots / Additional Context

Possible follow-up, intentionally out of scope to keep this fix minimal: the games table has no UNIQUE constraint, and "Delete duplicate games" partitions on the encoded moves blob, so it cannot remove re-imported copies whose move encoding differs (e.g. embedded clock annotations). A game-identity dedup key or a unique index would be a stronger backstop against duplicates from any source.

## Checklist
- [x] Followed contributing guidelines
- [x] Reviewed code for style and correctness
