### PR TITLE
Fix memory size refresh

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -28,7 +28,7 @@ use fide::FidePlayer;
 use oauth::AuthState;
 #[cfg(all(debug_assertions, not(target_os = "android")))]
 use specta_typescript::{BigIntExportBehavior, Typescript};
-use sysinfo::SystemExt;
+use sysinfo::{RefreshKind, SystemExt};
 use tauri::AppHandle;
 
 use crate::chess::{
@@ -212,7 +212,8 @@ fn is_bmi2_compatible() -> bool {
 #[tauri::command]
 #[specta::specta]
 fn memory_size() -> u64 {
-    sysinfo::System::new_all().total_memory() / (1024 * 1024)
+    sysinfo::System::new_with_specifics(RefreshKind::new().with_memory()).total_memory()
+        / (1024 * 1024)
 }
 
 #[tauri::command]


### PR DESCRIPTION
## Summary

Opening the analysis board could make the app hang on Linux.
The app was reading total memory by refreshing every `sysinfo` subsystem, including process data.
This change refreshes only memory, so the hash-size slider gets the same RAM value without opening thousands of `/proc/*/stat` files.

## What Changed

The backend memory command now asks `sysinfo` for memory only.
The returned value is still total system RAM in MiB, so the engine hash slider keeps the same behavior.

- Replaced `System::new_all()` with `System::new_with_specifics(RefreshKind::new().with_memory())` in `memory_size()`.
- Kept the existing MiB conversion and command shape unchanged.

## Testing

I tested the original failure signal directly in a dev build.
The fixed app stayed responsive after switching to the analysis tab, and the process did not accumulate `/proc/*/stat` file descriptors.

- `cargo fmt`
- `cargo check`
- Runtime check before analysis shortcut: `56` FDs, `0` `/proc/*/stat` FDs.
- Runtime check after `Shift+A`: `57` FDs, `0` `/proc/*/stat` FDs.
- Follow-up after 20s: `57` FDs, `0` `/proc/*/stat` FDs.
- No new user-journal unresponsive entries appeared.

Known upstream failures on latest `origin/main` commit `4fd9df0`:

- `pnpm test` fails in `src/utils/__tests__/store.test.ts` because test storage is undefined.
- `pnpm build-vite && cargo test` fails 7 existing `chess::evaluation` tests.
- `cargo clippy --all-targets --all-features` fails on existing unrelated clippy debt.

## Risks

Risk is low because the change narrows what gets refreshed.
It does not change the UI limit calculation or the value returned by `memory_size()`.

- The memory value still comes from `sysinfo`.
- The hash slider still caps values at half of detected system memory.