### PR TITLE
fix: restore Accounts in the sidebar nav

### DIFF
--- a/src/app/navigation.ts
+++ b/src/app/navigation.ts
@@ -7,6 +7,7 @@ import {
     IconLayoutDashboard,
     IconSettings,
     IconTarget,
+    IconUsers,
 } from "@tabler/icons-react";
 
 export type AppNavigationItem = {
@@ -14,6 +15,7 @@ export type AppNavigationItem = {
         | "dashboard"
         | "analysis"
         | "games"
+        | "accounts"
         | "databases"
         | "openings"
         | "repertoire"
@@ -49,6 +51,13 @@ export const appNavigationItems: AppNavigationItem[] = [
         labelKey: "features.sidebar.games",
         icon: IconChess,
         url: "/files",
+        section: "library",
+    },
+    {
+        id: "accounts",
+        labelKey: "features.sidebar.accounts",
+        icon: IconUsers,
+        url: "/accounts",
         section: "library",
     },
     {

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -42,6 +42,7 @@ const labelFallbacks: Record<AppNavigationItem["id"], string> = {
   dashboard: "Dashboard",
   analysis: "Analysis",
   games: "Games",
+  accounts: "Accounts",
   databases: "Databases",
   openings: "Openings",
   repertoire: "Repertoire",


### PR DESCRIPTION
## Summary

The Accounts page (Chess.com / Lichess link and bulk game download) still existed, but nothing in the UI could open it after the sidebar redesign. This puts **Accounts** back in the library section of the nav so that flow is reachable again.

## What Changed

The July UI/UX sidebar rewrite left `/accounts` out of `appNavigationItems` while keeping the route and feature code. This change adds it back.

- Add an Accounts item pointing at `/accounts` (after Games, before Databases).
- Use the existing `features.sidebar.accounts` label and `IconUsers`.
- Update sidebar label fallbacks so the new id type-checks cleanly.

## Testing

- Confirmed Accounts opens and works in the local Tauri dev app.
- `pnpm exec vitest run src/app/__tests__/commands.test.tsx` — 5 passed.
- Full CI will run on this PR.

## Risks

Low. Nav-only; does not change account download logic. Spotlight/command palette pick up the new item from the shared nav list.